### PR TITLE
upload charm workflow

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -9,6 +9,7 @@ jobs:
     name: Integration tests (microk8s)
     runs-on: ubuntu-latest
     steps:
+      - run: sudo apt install libffi-dev
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup operator environment

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -9,7 +9,6 @@ jobs:
     name: Integration tests (microk8s)
     runs-on: ubuntu-latest
     steps:
-      - run: sudo apt install libffi-dev
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup operator environment

--- a/.github/workflows/release_charm.yaml
+++ b/.github/workflows/release_charm.yaml
@@ -1,0 +1,33 @@
+name: Upload charm
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifact_id:
+        type: string
+        required: true
+
+jobs:
+  upload_charm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          repository: canonical/livepatch-server
+          github-token: "${{ secrets.GH_PAT }}"
+
+      - name: load images into local docker registry
+        run: |
+          echo "${{ inputs.artifact_id }}"
+          docker load -i livepatch-server.tar
+          docker load -i schema-tool.tar
+
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@main
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GH_PAT }}"
+          channel: "latest/edge"
+          pull-image: "false"
+          tag-prefix: "k8s"

--- a/.github/workflows/release_charm.yaml
+++ b/.github/workflows/release_charm.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: load images into local docker registry
         run: |
-          echo "${{ inputs.artifact_id }}"
+          echo "artifact_id: ${{ inputs.artifact_id }}"
           docker load -i livepatch-server.tar
           docker load -i schema-tool.tar
 

--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,0 +1,2 @@
+ignore_files:
+  - lib/charms/nginx_ingress_integrator/v0/ingress.py

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 .PHONY: microk8s-push operator-prod-k8s deploy-onprem-k8s

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Learn more about actions at: https://juju.is/docs/sdk/actions

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Learn more about charmcraft.yaml configuration at:

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Learn more about config at: https://juju.is/docs/sdk/config

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # Licensed under the Apache2.0. See LICENSE file in charm source for details.
 
 # Copyright 2023 Canonical Ltd.
@@ -351,9 +351,7 @@ def diff(event: RelationChangedEvent, bucket: str) -> Diff:
     # Retrieve the old data from the data key in the application relation databag.
     old_data = json.loads(event.relation.data[bucket].get("data", "{}"))
     # Retrieve the new data from the event relation databag.
-    new_data = {
-        key: value for key, value in event.relation.data[event.app].items() if key != "data"
-    }
+    new_data = {key: value for key, value in event.relation.data[event.app].items() if key != "data"}
 
     # These are the keys that were added to the databag and triggered this event.
     added = new_data.keys() - old_data.keys()
@@ -415,9 +413,7 @@ class DataProvides(Object, ABC):
         """
         data = {}
         for relation in self.relations:
-            data[relation.id] = {
-                key: value for key, value in relation.data[relation.app].items() if key != "data"
-            }
+            data[relation.id] = {key: value for key, value in relation.data[relation.app].items() if key != "data"}
         return data
 
     def _update_relation_data(self, relation_id: int, data: dict) -> None:
@@ -494,12 +490,8 @@ class DataRequires(Object, ABC):
         self.local_app = self.charm.model.app
         self.local_unit = self.charm.unit
         self.relation_name = relation_name
-        self.framework.observe(
-            self.charm.on[relation_name].relation_joined, self._on_relation_joined_event
-        )
-        self.framework.observe(
-            self.charm.on[relation_name].relation_changed, self._on_relation_changed_event
-        )
+        self.framework.observe(self.charm.on[relation_name].relation_joined, self._on_relation_joined_event)
+        self.framework.observe(self.charm.on[relation_name].relation_changed, self._on_relation_changed_event)
 
     @abstractmethod
     def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
@@ -523,9 +515,7 @@ class DataRequires(Object, ABC):
         """
         data = {}
         for relation in self.relations:
-            data[relation.id] = {
-                key: value for key, value in relation.data[relation.app].items() if key != "data"
-            }
+            data[relation.id] = {key: value for key, value in relation.data[relation.app].items() if key != "data"}
         return data
 
     def _update_relation_data(self, relation_id: int, data: dict) -> None:
@@ -574,9 +564,7 @@ class DataRequires(Object, ABC):
 
     @staticmethod
     def _is_resource_created_for_relation(relation: Relation):
-        return (
-            "username" in relation.data[relation.app] and "password" in relation.data[relation.app]
-        )
+        return "username" in relation.data[relation.app] and "password" in relation.data[relation.app]
 
     def is_resource_created(self, relation_id: Optional[int] = None) -> bool:
         """Check if the resource has been created.
@@ -596,20 +584,13 @@ class DataRequires(Object, ABC):
         """
         if relation_id is not None:
             try:
-                relation = [relation for relation in self.relations if relation.id == relation_id][
-                    0
-                ]
+                relation = [relation for relation in self.relations if relation.id == relation_id][0]
                 return self._is_resource_created_for_relation(relation)
             except IndexError:
                 raise IndexError(f"relation id {relation_id} cannot be accessed")
         else:
             return (
-                all(
-                    [
-                        self._is_resource_created_for_relation(relation)
-                        for relation in self.relations
-                    ]
-                )
+                all([self._is_resource_created_for_relation(relation) for relation in self.relations])
                 if self.relations
                 else False
             )
@@ -878,9 +859,7 @@ class DatabaseRequires(DataRequires):
 
             for relation_alias in relations_aliases:
                 self.on.define_event(f"{relation_alias}_database_created", DatabaseCreatedEvent)
-                self.on.define_event(
-                    f"{relation_alias}_endpoints_changed", DatabaseEndpointsChangedEvent
-                )
+                self.on.define_event(f"{relation_alias}_endpoints_changed", DatabaseEndpointsChangedEvent)
                 self.on.define_event(
                     f"{relation_alias}_read_only_endpoints_changed",
                     DatabaseReadOnlyEndpointsChangedEvent,
@@ -900,11 +879,7 @@ class DatabaseRequires(DataRequires):
 
         # Return if an alias was already assigned to this relation
         # (like when there are more than one unit joining the relation).
-        if (
-            self.charm.model.get_relation(self.relation_name, relation_id)
-            .data[self.local_unit]
-            .get("alias")
-        ):
+        if self.charm.model.get_relation(self.relation_name, relation_id).data[self.local_unit].get("alias"):
             return
 
         # Retrieve the available aliases (the ones that weren't assigned to any relation).
@@ -928,9 +903,7 @@ class DatabaseRequires(DataRequires):
         """
         alias = self._get_relation_alias(event.relation.id)
         if alias:
-            getattr(self.on, f"{alias}_{event_name}").emit(
-                event.relation, app=event.app, unit=event.unit
-            )
+            getattr(self.on, f"{alias}_{event_name}").emit(event.relation, app=event.app, unit=event.unit)
 
     def _get_relation_alias(self, relation_id: int) -> Optional[str]:
         """Returns the relation alias.
@@ -974,18 +947,14 @@ class DatabaseRequires(DataRequires):
         host = host.split(":")[0]
         user = relation_data.get("username")
         password = relation_data.get("password")
-        connection_string = (
-            f"host='{host}' dbname='{self.database}' user='{user}' password='{password}'"
-        )
+        connection_string = f"host='{host}' dbname='{self.database}' user='{user}' password='{password}'"
         try:
             with psycopg.connect(connection_string) as connection:
                 with connection.cursor() as cursor:
                     cursor.execute(f"SELECT TRUE FROM pg_extension WHERE extname='{plugin}';")
                     return cursor.fetchone() is not None
         except psycopg.Error as e:
-            logger.exception(
-                f"failed to check whether {plugin} plugin is enabled in the database: %s", str(e)
-            )
+            logger.exception(f"failed to check whether {plugin} plugin is enabled in the database: %s", str(e))
             return False
 
     def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
@@ -1044,9 +1013,7 @@ class DatabaseRequires(DataRequires):
         if "read-only-endpoints" in diff.added or "read-only-endpoints" in diff.changed:
             # Emit the default event (the one without an alias).
             logger.info("read-only-endpoints changed on %s", datetime.now())
-            self.on.read_only_endpoints_changed.emit(
-                event.relation, app=event.app, unit=event.unit
-            )
+            self.on.read_only_endpoints_changed.emit(event.relation, app=event.app, unit=event.unit)
 
             # Emit the aliased event (if any).
             self._emit_aliased_event(event, "read_only_endpoints_changed")
@@ -1210,8 +1177,7 @@ class KafkaRequires(DataRequires):
         """Event emitted when the application joins the Kafka relation."""
         # Sets topic, extra user roles, and "consumer-group-prefix" in the relation
         relation_data = {
-            f: getattr(self, f.replace("-", "_"), "")
-            for f in ["consumer-group-prefix", "extra-user-roles", "topic"]
+            f: getattr(self, f.replace("-", "_"), "") for f in ["consumer-group-prefix", "extra-user-roles", "topic"]
         }
 
         self._update_relation_data(event.relation.id, relation_data)
@@ -1347,9 +1313,7 @@ class OpenSearchRequires(DataRequires):
 
     on = OpenSearchRequiresEvents()
 
-    def __init__(
-        self, charm, relation_name: str, index: str, extra_user_roles: Optional[str] = None
-    ):
+    def __init__(self, charm, relation_name: str, index: str, extra_user_roles: Optional[str] = None):
         """Manager of OpenSearch client relations."""
         super().__init__(charm, relation_name, extra_user_roles)
         self.charm = charm

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # Licensed under the Apache2.0. See LICENSE file in charm source for details.
 
 # Copyright 2021 Canonical Ltd.
@@ -417,11 +417,8 @@ class RelationInterfaceMismatchError(Exception):
         self.relation_name = relation_name
         self.expected_relation_interface = expected_relation_interface
         self.actual_relation_interface = actual_relation_interface
-        self.message = (
-            "The '{}' relation has '{}' as "
-            "interface rather than the expected '{}'".format(
-                relation_name, actual_relation_interface, expected_relation_interface
-            )
+        self.message = "The '{}' relation has '{}' as " "interface rather than the expected '{}'".format(
+            relation_name, actual_relation_interface, expected_relation_interface
         )
 
         super().__init__(self.message)
@@ -529,20 +526,14 @@ def _validate_relation_by_interface_and_direction(
 
     actual_relation_interface = relation.interface_name
     if actual_relation_interface != expected_relation_interface:
-        raise RelationInterfaceMismatchError(
-            relation_name, expected_relation_interface, actual_relation_interface
-        )
+        raise RelationInterfaceMismatchError(relation_name, expected_relation_interface, actual_relation_interface)
 
     if expected_relation_role == RelationRole.provides:
         if relation_name not in charm.meta.provides:
-            raise RelationRoleMismatchError(
-                relation_name, RelationRole.provides, RelationRole.requires
-            )
+            raise RelationRoleMismatchError(relation_name, RelationRole.provides, RelationRole.requires)
     elif expected_relation_role == RelationRole.requires:
         if relation_name not in charm.meta.requires:
-            raise RelationRoleMismatchError(
-                relation_name, RelationRole.requires, RelationRole.provides
-            )
+            raise RelationRoleMismatchError(relation_name, RelationRole.requires, RelationRole.provides)
     else:
         raise Exception("Unexpected RelationDirection: {}".format(expected_relation_role))
 
@@ -604,9 +595,7 @@ def _convert_dashboard_fields(content: str, inject_dropdowns: bool = True) -> st
     return json.dumps(dict_content)
 
 
-def _replace_template_fields(  # noqa: C901
-    dict_content: dict, datasources: dict, existing_templates: bool
-) -> dict:
+def _replace_template_fields(dict_content: dict, datasources: dict, existing_templates: bool) -> dict:  # noqa: C901
     """Make templated fields get cleaned up afterwards.
 
     If existing datasource variables are present, try to substitute them.
@@ -1083,9 +1072,7 @@ class GrafanaDashboardProvider(Object):
         # it is predictable across units.
         id = "prog:{}".format(encoded_dashboard[-24:-16])
 
-        stored_dashboard_templates[id] = self._content_to_dashboard_object(
-            encoded_dashboard, inject_dropdowns
-        )
+        stored_dashboard_templates[id] = self._content_to_dashboard_object(encoded_dashboard, inject_dropdowns)
         stored_dashboard_templates[id]["dashboard_alt_uid"] = self._generate_alt_uid(id)
 
         if self._charm.unit.is_leader():
@@ -1113,9 +1100,7 @@ class GrafanaDashboardProvider(Object):
             for dashboard_relation in self._charm.model.relations[self._relation_name]:
                 self._upset_dashboards_on_relation(dashboard_relation)
 
-    def _update_all_dashboards_from_dir(
-        self, _: Optional[HookEvent] = None, inject_dropdowns: bool = True
-    ) -> None:
+    def _update_all_dashboards_from_dir(self, _: Optional[HookEvent] = None, inject_dropdowns: bool = True) -> None:
         """Scans the built-in dashboards and updates relations with changes."""
         # Update of storage must be done irrespective of leadership, so
         # that the stored state is there when this unit becomes leader.
@@ -1217,9 +1202,7 @@ class GrafanaDashboardProvider(Object):
             if valid and not errors:
                 self.on.dashboard_status_changed.emit(valid=valid)  # pyright: ignore
             else:
-                self.on.dashboard_status_changed.emit(  # pyright: ignore
-                    valid=valid, errors=errors
-                )
+                self.on.dashboard_status_changed.emit(valid=valid, errors=errors)  # pyright: ignore
 
     def _upset_dashboards_on_relation(self, relation: Relation) -> None:
         """Update the dashboards in the relation data bucket."""
@@ -1334,8 +1317,7 @@ class GrafanaDashboardConsumer(Object):
         Returns: a list of known dashboards coming from the provided relation instance.
         """
         return [
-            self._to_external_object(relation_id, dashboard)
-            for dashboard in self._get_stored_dashboards(relation_id)
+            self._to_external_object(relation_id, dashboard) for dashboard in self._get_stored_dashboards(relation_id)
         ]
 
     def _on_grafana_dashboard_relation_changed(self, event: RelationChangedEvent) -> None:
@@ -1373,9 +1355,7 @@ class GrafanaDashboardConsumer(Object):
                 :class:`GrafanaDashboardConsumer` will be updated.
         """
         if self._charm.unit.is_leader():
-            relations = (
-                [relation] if relation else self._charm.model.relations[self._relation_name]
-            )
+            relations = [relation] if relation else self._charm.model.relations[self._relation_name]
 
             for relation in relations:
                 self._render_dashboards_and_signal_changed(relation)
@@ -1471,9 +1451,7 @@ class GrafanaDashboardConsumer(Object):
         if relation_has_invalid_dashboards:
             self._remove_all_dashboards_for_relation(relation)
 
-            invalid_templates = [
-                data["original_id"] for data in rendered_dashboards if not data["valid"]
-            ]
+            invalid_templates = [data["original_id"] for data in rendered_dashboards if not data["valid"]]
 
             logger.warning(
                 "Cannot add one or more Grafana dashboards from relation '{}:{}': the following "
@@ -1546,9 +1524,7 @@ class GrafanaDashboardConsumer(Object):
         """
         dashboards = []
 
-        for _, (relation_id, dashboards_for_relation) in enumerate(
-            self.get_peer_data("dashboards").items()
-        ):
+        for _, (relation_id, dashboards_for_relation) in enumerate(self.get_peer_data("dashboards").items()):
             for dashboard in dashboards_for_relation:
                 dashboards.append(self._to_external_object(relation_id, dashboard))
 
@@ -1657,9 +1633,7 @@ class GrafanaDashboardAggregator(Object):
         dashboards = self._handle_reactive_dashboards(event)
 
         if not dashboards:
-            logger.warning(
-                "Could not find dashboard data after a relation change for {}".format(event.app)
-            )
+            logger.warning("Could not find dashboard data after a relation change for {}".format(event.app))
             return
 
         for id in dashboards:
@@ -1805,9 +1779,7 @@ class GrafanaDashboardAggregator(Object):
             # Replace the old-style datasource templates
             dash = re.sub(r"<< datasource >>", r"${prometheusds}", dash)
             dash = re.sub(r'"datasource": "prom.*?"', r'"datasource": "${prometheusds}"', dash)
-            dash = re.sub(
-                r'"datasource": "\$datasource"', r'"datasource": "${prometheusds}"', dash
-            )
+            dash = re.sub(r'"datasource": "\$datasource"', r'"datasource": "${prometheusds}"', dash)
             dash = re.sub(r'"uid": "\$datasource"', r'"uid": "${prometheusds}"', dash)
             dash = re.sub(
                 r'"datasource": "(!?\w)[\w|\s|-]+?Juju generated.*?"',
@@ -1816,9 +1788,7 @@ class GrafanaDashboardAggregator(Object):
             )
 
             # Yank out "new"+old LMA topology
-            dash = re.sub(
-                r'(,?\s?juju_application=~)\\"\$app\\"', r'\1\\"$juju_application\\"', dash
-            )
+            dash = re.sub(r'(,?\s?juju_application=~)\\"\$app\\"', r'\1\\"$juju_application\\"', dash)
 
             # Replace old piechart panels
             dash = re.sub(r'"type": "grafana-piechart-panel"', '"type": "piechart"', dash)
@@ -1845,9 +1815,7 @@ class GrafanaDashboardAggregator(Object):
         dashboards_path = None
 
         try:
-            dashboards_path = _resolve_dir_against_charm_path(
-                self._charm, "src/grafana_dashboards"
-            )
+            dashboards_path = _resolve_dir_against_charm_path(self._charm, "src/grafana_dashboards")
         except InvalidDirectoryPathError as e:
             logger.warning(
                 "Invalid Grafana dashboards folder at %s: %s",
@@ -1978,12 +1946,7 @@ class CosTool:
         args = [str(self.path), "--format", type, "transform"]
 
         variable_topology = {k: "${}".format(k) for k in topology.keys()}
-        args.extend(
-            [
-                "--label-matcher={}={}".format(key, value)
-                for key, value in variable_topology.items()
-            ]
-        )
+        args.extend(["--label-matcher={}={}".format(key, value) for key, value in variable_topology.items()])
 
         # Pass a leading "--" so expressions with a negation or subtraction aren't interpreted as
         # flags

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # Licensed under the Apache2.0. See LICENSE file in charm source for details.
 
-# Copyright 2021 Canonical Ltd.
-# See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk
 
@@ -543,10 +541,8 @@ class RelationInterfaceMismatchError(Exception):
         self.relation_name = relation_name
         self.expected_relation_interface = expected_relation_interface
         self.actual_relation_interface = actual_relation_interface
-        self.message = (
-            "The '{}' relation has '{}' as interface rather than the expected '{}'".format(
-                relation_name, actual_relation_interface, expected_relation_interface
-            )
+        self.message = "The '{}' relation has '{}' as interface rather than the expected '{}'".format(
+            relation_name, actual_relation_interface, expected_relation_interface
         )
         super().__init__(self.message)
 
@@ -607,20 +603,14 @@ def _validate_relation_by_interface_and_direction(
 
     actual_relation_interface = relation.interface_name
     if actual_relation_interface != expected_relation_interface:
-        raise RelationInterfaceMismatchError(
-            relation_name, expected_relation_interface, actual_relation_interface
-        )
+        raise RelationInterfaceMismatchError(relation_name, expected_relation_interface, actual_relation_interface)
 
     if expected_relation_role == RelationRole.provides:
         if relation_name not in charm.meta.provides:
-            raise RelationRoleMismatchError(
-                relation_name, RelationRole.provides, RelationRole.requires
-            )
+            raise RelationRoleMismatchError(relation_name, RelationRole.provides, RelationRole.requires)
     elif expected_relation_role == RelationRole.requires:
         if relation_name not in charm.meta.requires:
-            raise RelationRoleMismatchError(
-                relation_name, RelationRole.requires, RelationRole.provides
-            )
+            raise RelationRoleMismatchError(relation_name, RelationRole.requires, RelationRole.provides)
     else:
         raise Exception("Unexpected RelationDirection: {}".format(expected_relation_role))
 
@@ -808,9 +798,7 @@ class AlertRules:
             # Note that Path doesn't actually care whether the path is valid just to instantiate
             # the object, so we can happily strip that stuff out to make templating nicer
             rel_path = Path(
-                re.sub(r"^([A-Za-z]+:)?/", "", rel_path.as_posix())
-                if rel_path.is_absolute()
-                else str(rel_path)
+                re.sub(r"^([A-Za-z]+:)?/", "", rel_path.as_posix()) if rel_path.is_absolute() else str(rel_path)
             )
 
             # Get rid of relative path characters in the middle which both os.path and pathlib
@@ -828,9 +816,7 @@ class AlertRules:
         return "_".join(filter(lambda x: x, group_name_parts))
 
     @classmethod
-    def _multi_suffix_glob(
-        cls, dir_path: Path, suffixes: List[str], recursive: bool = True
-    ) -> list:
+    def _multi_suffix_glob(cls, dir_path: Path, suffixes: List[str], recursive: bool = True) -> list:
         """Helper function for getting all files in a directory that have a matching suffix.
 
         Args:
@@ -939,10 +925,8 @@ class NoRelationWithInterfaceFoundError(Exception):
     def __init__(self, charm: CharmBase, relation_interface: Optional[str] = None):
         self.charm = charm
         self.relation_interface = relation_interface
-        self.message = (
-            "No relations with interface '{}' found in the meta of the '{}' charm".format(
-                relation_interface, charm.meta.name
-            )
+        self.message = "No relations with interface '{}' found in the meta of the '{}' charm".format(
+            relation_interface, charm.meta.name
         )
 
         super().__init__(self.message)
@@ -955,10 +939,8 @@ class MultipleRelationsWithInterfaceFoundError(Exception):
         self.charm = charm
         self.relation_interface = relation_interface
         self.relations = relations
-        self.message = (
-            "Multiple relations with interface '{}' found in the meta of the '{}' charm.".format(
-                relation_interface, charm.meta.name
-            )
+        self.message = "Multiple relations with interface '{}' found in the meta of the '{}' charm.".format(
+            relation_interface, charm.meta.name
         )
         super().__init__(self.message)
 
@@ -1005,9 +987,7 @@ class LokiPushApiAlertRulesChanged(EventBase):
 
     def restore(self, snapshot: dict):
         """Restore event information."""
-        self.relation = self.framework.model.get_relation(
-            snapshot["relation_name"], snapshot["relation_id"]
-        )
+        self.relation = self.framework.model.get_relation(snapshot["relation_name"], snapshot["relation_id"])
         app_name = snapshot.get("app_name")
         if app_name:
             self.app = self.framework.model.get_app(app_name)
@@ -1225,9 +1205,7 @@ class LokiPushApiProvider(Object):
         # construct promtail binary url paths from parts
         promtail_binaries = {}
         for arch, info in PROMTAIL_BINARIES.items():
-            info["url"] = "{}/promtail-{}/{}.gz".format(
-                PROMTAIL_BASE_URL, PROMTAIL_VERSION, info["filename"]
-            )
+            info["url"] = "{}/promtail-{}/{}.gz".format(PROMTAIL_BASE_URL, PROMTAIL_VERSION, info["filename"])
             promtail_binaries[arch] = info
 
         return {"promtail_binary_zip_url": json.dumps(promtail_binaries)}
@@ -1339,9 +1317,7 @@ class LokiPushApiProvider(Object):
                     )
 
             if not identifier:
-                logger.error(
-                    "Alert rules were found but no usable group or identifier was present."
-                )
+                logger.error("Alert rules were found but no usable group or identifier was present.")
                 continue
 
             _, errmsg = self._tool.validate_alert_rules(alert_rules)
@@ -1353,9 +1329,7 @@ class LokiPushApiProvider(Object):
 
         return alerts
 
-    def _get_identifier_by_alert_rules(
-        self, rules: dict
-    ) -> Tuple[Union[str, None], Union[JujuTopology, None]]:
+    def _get_identifier_by_alert_rules(self, rules: dict) -> Tuple[Union[str, None], Union[JujuTopology, None]]:
         """Determine an appropriate dict key for alert rules.
 
         The key is used as the filename when writing alerts to disk, so the structure
@@ -1479,9 +1453,7 @@ class ConsumerBase(Object):
         if not self._charm.unit.is_leader():
             return
 
-        alert_rules = (
-            AlertRules(None) if self._skip_alert_topology_labeling else AlertRules(self.topology)
-        )
+        alert_rules = AlertRules(None) if self._skip_alert_topology_labeling else AlertRules(self.topology)
         alert_rules.add_path(self._alert_rules_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
 
@@ -1578,9 +1550,7 @@ class LokiPushApiConsumer(ConsumerBase):
         _validate_relation_by_interface_and_direction(
             charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.requires
         )
-        super().__init__(
-            charm, relation_name, alert_rules_path, recursive, skip_alert_topology_labeling
-        )
+        super().__init__(charm, relation_name, alert_rules_path, recursive, skip_alert_topology_labeling)
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_lifecycle_event)
         self.framework.observe(events.relation_joined, self._on_logging_relation_joined)
@@ -1852,9 +1822,7 @@ class LogProxyConsumer(ConsumerBase):
 
             new_config = self._promtail_config
             if new_config != self._current_config:
-                self._container.push(
-                    WORKLOAD_CONFIG_PATH, yaml.safe_dump(new_config), make_dirs=True
-                )
+                self._container.push(WORKLOAD_CONFIG_PATH, yaml.safe_dump(new_config), make_dirs=True)
 
             # Loki may send endpoints late. Don't necessarily start, there may be
             # no clients
@@ -2071,9 +2039,7 @@ class LogProxyConsumer(ConsumerBase):
                 result = sha256(file_bytes).hexdigest()
 
                 if result != sha256sum:
-                    msg = "File sha256sum mismatch, expected:'{}' but got '{}'".format(
-                        sha256sum, result
-                    )
+                    msg = "File sha256sum mismatch, expected:'{}' but got '{}'".format(sha256sum, result)
                     logger.debug(msg)
                     return False
 
@@ -2147,8 +2113,7 @@ class LogProxyConsumer(ConsumerBase):
             return yaml.safe_load(raw_current)
         except (ProtocolError, PathError) as e:
             logger.warning(
-                "Could not check the current promtail configuration due to "
-                "a failure in retrieving the file: %s",
+                "Could not check the current promtail configuration due to " "a failure in retrieving the file: %s",
                 e,
             )
             return {}
@@ -2201,8 +2166,7 @@ class LogProxyConsumer(ConsumerBase):
 
         # The new JujuTopology doesn't include unit, but LogProxyConsumer should have it
         common_labels = {
-            "juju_{}".format(k): v
-            for k, v in self.topology.as_dict(remapped_keys={"charm_name": "charm"}).items()
+            "juju_{}".format(k): v for k, v in self.topology.as_dict(remapped_keys={"charm_name": "charm"}).items()
         }
         scrape_configs = []
 
@@ -2270,14 +2234,10 @@ class LogProxyConsumer(ConsumerBase):
         relations = self._charm.model.relations[self._relation_name]
         if len(relations) > 1:
             logger.debug(
-                "Multiple log_proxy relations. Getting Promtail from application {}".format(
-                    relations[0].app.name
-                )
+                "Multiple log_proxy relations. Getting Promtail from application {}".format(relations[0].app.name)
             )
         relation = relations[0]
-        promtail_binaries = json.loads(
-            relation.data[relation.app].get("promtail_binary_zip_url", "{}")
-        )
+        promtail_binaries = json.loads(relation.data[relation.app].get("promtail_binary_zip_url", "{}"))
         if not promtail_binaries:
             return
 
@@ -2290,14 +2250,10 @@ class LogProxyConsumer(ConsumerBase):
                 self.on.promtail_digest_error.emit(msg)
                 return
 
-        workload_binary_path = os.path.join(
-            WORKLOAD_BINARY_DIR, promtail_binaries[self._arch]["filename"]
-        )
+        workload_binary_path = os.path.join(WORKLOAD_BINARY_DIR, promtail_binaries[self._arch]["filename"])
 
         self._create_directories()
-        self._container.push(
-            WORKLOAD_CONFIG_PATH, yaml.safe_dump(self._promtail_config), make_dirs=True
-        )
+        self._container.push(WORKLOAD_CONFIG_PATH, yaml.safe_dump(self._promtail_config), make_dirs=True)
 
         self._add_pebble_layer(workload_binary_path)
 
@@ -2431,9 +2387,7 @@ class CosTool:
             logger.debug("`cos-tool` unavailable. Leaving expression unchanged: %s", expression)
             return expression
         args = [str(self.path), "--format", "logql", "transform"]
-        args.extend(
-            ["--label-matcher={}={}".format(key, value) for key, value in topology.items()]
-        )
+        args.extend(["--label-matcher={}={}".format(key, value) for key, value in topology.items()])
 
         args.extend(["{}".format(expression)])
         # noinspection PyBroadException

--- a/lib/charms/nginx_ingress_integrator/v0/ingress.py
+++ b/lib/charms/nginx_ingress_integrator/v0/ingress.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # Licensed under the Apache2.0. See LICENSE file in charm source for details.
 
 """Library for the ingress relation.
@@ -128,9 +128,7 @@ class IngressRequires(Object):
         """Check our config dict for errors."""
         blocked_message = "Error in ingress relation, check `juju debug-log`"
         unknown = [
-            x
-            for x in self.config_dict
-            if x not in REQUIRED_INGRESS_RELATION_FIELDS | OPTIONAL_INGRESS_RELATION_FIELDS
+            x for x in self.config_dict if x not in REQUIRED_INGRESS_RELATION_FIELDS | OPTIONAL_INGRESS_RELATION_FIELDS
         ]
         if unknown:
             logger.error(
@@ -200,22 +198,12 @@ class IngressProvides(Object):
         }
 
         missing_fields = sorted(
-            [
-                field
-                for field in REQUIRED_INGRESS_RELATION_FIELDS
-                if ingress_data.get(field) is None
-            ]
+            [field for field in REQUIRED_INGRESS_RELATION_FIELDS if ingress_data.get(field) is None]
         )
 
         if missing_fields:
-            logger.error(
-                "Missing required data fields for ingress relation: {}".format(
-                    ", ".join(missing_fields)
-                )
-            )
-            self.model.unit.status = BlockedStatus(
-                "Missing fields for ingress: {}".format(", ".join(missing_fields))
-            )
+            logger.error("Missing required data fields for ingress relation: {}".format(", ".join(missing_fields)))
+            self.model.unit.status = BlockedStatus("Missing fields for ingress: {}".format(", ".join(missing_fields)))
 
         # Create an event that our charm can use to decide it's okay to
         # configure the ingress.

--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # Licensed under the Apache2.0. See LICENSE file in charm source for details.
 
 """## Overview.

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1,8 +1,6 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # Licensed under the Apache2.0. See LICENSE file in charm source for details.
 
-# Copyright 2021 Canonical Ltd.
-# See LICENSE file for licensing details.
 """Prometheus Scrape Library.
 
 ## Overview
@@ -547,9 +545,7 @@ class PrometheusConfig:
                         unit_num = unit_name.split("/")[-1]
                         job_name = modified_job.get("job_name", "unnamed-job") + "-" + unit_num
                         modified_job["job_name"] = job_name
-                        modified_job["metrics_path"] = unit_path + (
-                            job.get("metrics_path") or "/metrics"
-                        )
+                        modified_job["metrics_path"] = unit_path + (job.get("metrics_path") or "/metrics")
 
                         if topology:
                             # Add topology labels
@@ -560,9 +556,9 @@ class PrometheusConfig:
                             }
 
                             # Instance relabeling for topology should be last in order.
-                            modified_job["relabel_configs"] = modified_job.get(
-                                "relabel_configs", []
-                            ) + [PrometheusConfig.topology_relabel_config_wildcard]
+                            modified_job["relabel_configs"] = modified_job.get("relabel_configs", []) + [
+                                PrometheusConfig.topology_relabel_config_wildcard
+                            ]
 
                         modified_scrape_jobs.append(modified_job)
 
@@ -639,10 +635,8 @@ class RelationInterfaceMismatchError(Exception):
         self.relation_name = relation_name
         self.expected_relation_interface = expected_relation_interface
         self.actual_relation_interface = actual_relation_interface
-        self.message = (
-            "The '{}' relation has '{}' as interface rather than the expected '{}'".format(
-                relation_name, actual_relation_interface, expected_relation_interface
-            )
+        self.message = "The '{}' relation has '{}' as interface rather than the expected '{}'".format(
+            relation_name, actual_relation_interface, expected_relation_interface
         )
 
         super().__init__(self.message)
@@ -764,20 +758,14 @@ def _validate_relation_by_interface_and_direction(
 
     actual_relation_interface = relation.interface_name
     if actual_relation_interface != expected_relation_interface:
-        raise RelationInterfaceMismatchError(
-            relation_name, expected_relation_interface, actual_relation_interface
-        )
+        raise RelationInterfaceMismatchError(relation_name, expected_relation_interface, actual_relation_interface)
 
     if expected_relation_role == RelationRole.provides:
         if relation_name not in charm.meta.provides:
-            raise RelationRoleMismatchError(
-                relation_name, RelationRole.provides, RelationRole.requires
-            )
+            raise RelationRoleMismatchError(relation_name, RelationRole.provides, RelationRole.requires)
     elif expected_relation_role == RelationRole.requires:
         if relation_name not in charm.meta.requires:
-            raise RelationRoleMismatchError(
-                relation_name, RelationRole.requires, RelationRole.provides
-            )
+            raise RelationRoleMismatchError(relation_name, RelationRole.requires, RelationRole.provides)
     else:
         raise Exception("Unexpected RelationDirection: {}".format(expected_relation_role))
 
@@ -957,9 +945,7 @@ class AlertRules:
         return "_".join(filter(None, group_name_parts))
 
     @classmethod
-    def _multi_suffix_glob(
-        cls, dir_path: Path, suffixes: List[str], recursive: bool = True
-    ) -> list:
+    def _multi_suffix_glob(cls, dir_path: Path, suffixes: List[str], recursive: bool = True) -> list:
         """Helper function for getting all files in a directory that have a matching suffix.
 
         Args:
@@ -991,9 +977,7 @@ class AlertRules:
         alert_groups = []  # type: List[dict]
 
         # Gather all alerts into a list of groups
-        for file_path in self._multi_suffix_glob(
-            dir_path, [".rule", ".rules", ".yml", ".yaml"], recursive
-        ):
+        for file_path in self._multi_suffix_glob(dir_path, [".rule", ".rules", ".yml", ".yaml"], recursive):
             alert_groups_from_file = self._from_file(dir_path, file_path)
             if alert_groups_from_file:
                 logger.debug("Reading alert rule from %s", file_path)
@@ -1092,9 +1076,7 @@ class MetricsEndpointConsumer(Object):
         self._tool = CosTool(self._charm)
         events = self._charm.on[relation_name]
         self.framework.observe(events.relation_changed, self._on_metrics_provider_relation_changed)
-        self.framework.observe(
-            events.relation_departed, self._on_metrics_provider_relation_departed
-        )
+        self.framework.observe(events.relation_departed, self._on_metrics_provider_relation_departed)
 
     def _on_metrics_provider_relation_changed(self, event):
         """Handle changes with related metrics providers.
@@ -1225,9 +1207,7 @@ class MetricsEndpointConsumer(Object):
                     )
 
             if not identifier:
-                logger.error(
-                    "Alert rules were found but no usable group or identifier was present."
-                )
+                logger.error("Alert rules were found but no usable group or identifier was present.")
                 continue
 
             alerts[identifier] = alert_rules
@@ -1244,9 +1224,7 @@ class MetricsEndpointConsumer(Object):
 
         return alerts
 
-    def _get_identifier_by_alert_rules(
-        self, rules: dict
-    ) -> Tuple[Union[str, None], Union[JujuTopology, None]]:
+    def _get_identifier_by_alert_rules(self, rules: dict) -> Tuple[Union[str, None], Union[JujuTopology, None]]:
         """Determine an appropriate dict key for alert rules.
 
         The key is used as the filename when writing alerts to disk, so the structure
@@ -1373,9 +1351,7 @@ class MetricsEndpointConsumer(Object):
 
         hosts = self._relation_hosts(relation)
 
-        scrape_jobs = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
-            scrape_jobs, hosts, topology
-        )
+        scrape_jobs = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(scrape_jobs, hosts, topology)
 
         return scrape_jobs
 
@@ -1386,9 +1362,9 @@ class MetricsEndpointConsumer(Object):
             # TODO deprecate and remove unit.name
             unit_name = relation.data[unit].get("prometheus_scrape_unit_name") or unit.name
             # TODO deprecate and remove "prometheus_scrape_host"
-            unit_address = relation.data[unit].get(
-                "prometheus_scrape_unit_address"
-            ) or relation.data[unit].get("prometheus_scrape_host")
+            unit_address = relation.data[unit].get("prometheus_scrape_unit_address") or relation.data[unit].get(
+                "prometheus_scrape_host"
+            )
             unit_path = relation.data[unit].get("prometheus_scrape_unit_path", "")
             if unit_name and unit_address:
                 hosts.update({unit_name: (unit_address, unit_path)})
@@ -1429,8 +1405,7 @@ def _dedupe_job_names(jobs: List[dict]):
     # Convert to a dict with job names as keys
     # I think this line is O(n^2) but it should be okay given the list sizes
     jobs_dict = {
-        job["job_name"]: list(filter(lambda x: x["job_name"] == job["job_name"], jobs_copy))
-        for job in jobs_copy
+        job["job_name"]: list(filter(lambda x: x["job_name"] == job["job_name"], jobs_copy)) for job in jobs_copy
     }
 
     # If multiple jobs have the same name, convert the name to "name_<hash-of-job>"
@@ -1650,9 +1625,7 @@ class MetricsEndpointProvider(Object):
         self._jobs = PrometheusConfig.sanitize_scrape_configs(jobs)
 
         if external_url:
-            external_url = (
-                external_url if urlparse(external_url).scheme else ("http://" + external_url)
-            )
+            external_url = external_url if urlparse(external_url).scheme else ("http://" + external_url)
         self.external_url = external_url
         self._lookaside_jobs = lookaside_jobs_callable
 
@@ -1767,9 +1740,7 @@ class MetricsEndpointProvider(Object):
 
             relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = unit_address
             relation.data[self._charm.unit]["prometheus_scrape_unit_path"] = path
-            relation.data[self._charm.unit]["prometheus_scrape_unit_name"] = str(
-                self._charm.model.unit.name
-            )
+            relation.data[self._charm.unit]["prometheus_scrape_unit_name"] = str(self._charm.model.unit.name)
 
     def _is_valid_unit_address(self, address: str) -> bool:
         """Validate a unit address.
@@ -1996,9 +1967,7 @@ class MetricsEndpointAggregator(Object):
 
         relation_names = relation_names or {}
 
-        self._prometheus_relation = relation_names.get(
-            "prometheus", "downstream-prometheus-scrape"
-        )
+        self._prometheus_relation = relation_names.get("prometheus", "downstream-prometheus-scrape")
         self._target_relation = relation_names.get("scrape_target", "prometheus-target")
         self._alert_rules_relation = relation_names.get("alert_rules", "prometheus-rules")
 
@@ -2015,9 +1984,7 @@ class MetricsEndpointAggregator(Object):
         # manage list of Prometheus scrape jobs from related scrape targets
         target_events = self._charm.on[self._target_relation]
         self.framework.observe(target_events.relation_changed, self._on_prometheus_targets_changed)
-        self.framework.observe(
-            target_events.relation_departed, self._on_prometheus_targets_departed
-        )
+        self.framework.observe(target_events.relation_departed, self._on_prometheus_targets_departed)
 
         # manage alert rules for Prometheus from related scrape targets
         alert_rule_events = self._charm.on[self._alert_rules_relation]
@@ -2034,9 +2001,7 @@ class MetricsEndpointAggregator(Object):
         if not self._charm.unit.is_leader():
             return
 
-        jobs = [] + _type_convert_stored(
-            self._stored.jobs
-        )  # list of scrape jobs, one per relation
+        jobs = [] + _type_convert_stored(self._stored.jobs)  # list of scrape jobs, one per relation
         for relation in self.model.relations[self._target_relation]:
             targets = self._get_targets(relation)
             if targets and relation.app:
@@ -2161,9 +2126,7 @@ class MetricsEndpointAggregator(Object):
         Returns:
             a string Prometheus scrape job name for the application.
         """
-        return "juju_{}_{}_{}_prometheus_scrape".format(
-            self.model.name, self.model.uuid[:7], appname
-        )
+        return "juju_{}_{}_{}_prometheus_scrape".format(self.model.name, self.model.uuid[:7], appname)
 
     def _get_targets(self, relation) -> dict:
         """Fetch scrape targets for a relation.
@@ -2380,9 +2343,7 @@ class MetricsEndpointAggregator(Object):
                 changed_group["rules"] = rules_kept  # type: ignore
                 groups.append(changed_group)
 
-            relation.data[self._charm.app]["alert_rules"] = (
-                json.dumps({"groups": groups}) if groups else "{}"
-            )
+            relation.data[self._charm.app]["alert_rules"] = json.dumps({"groups": groups}) if groups else "{}"
 
             if not _type_convert_stored(self._stored.alert_rules) == groups:
                 self._stored.alert_rules = groups
@@ -2519,11 +2480,7 @@ class CosTool:
             except subprocess.CalledProcessError as e:
                 logger.debug("Validating the rules failed: %s", e.output)
                 return False, ", ".join(
-                    [
-                        line
-                        for line in e.output.decode("utf8").splitlines()
-                        if "error validating" in line
-                    ]
+                    [line for line in e.output.decode("utf8").splitlines() if "error validating" in line]
                 )
 
     def validate_scrape_jobs(self, jobs: list) -> bool:
@@ -2550,9 +2507,7 @@ class CosTool:
             logger.debug("`cos-tool` unavailable. Leaving expression unchanged: %s", expression)
             return expression
         args = [str(self.path), "transform"]
-        args.extend(
-            ["--label-matcher={}={}".format(key, value) for key, value in topology.items()]
-        )
+        args.extend(["--label-matcher={}={}".format(key, value) for key, value in topology.items()])
 
         args.extend(["{}".format(expression)])
         # noinspection PyBroadException

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,6 +16,7 @@ maintainers:
 website: https://ubuntu.com/security/livepatch
 docs: https://discourse.ubuntu.com/t/ubuntu-livepatch-service/22723
 issues: https://bugs.launchpad.net/livepatch-onprem
+source: https://github.com/canonical/livepatch-k8s-operator
 
 subordinate: false
 tags:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # For a complete list of supported options, see:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ profile = "black"
 line_length = 120 # If this is removed, isort fights with Black
 
 
+[tool.bandit]
+exclude_dirs = ["/venv/"]
+[tool.bandit.assert_used]
+skips = ["*tests/*", "*_test.py", "*test_*.py"]
+
 # Linting tools configuration
 [tool.flake8]
 max-line-length = 120

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,0 @@
--r requirements.txt
-coverage == 6.4.2
-flake8 == 4.0.1
-autologging == 1.3.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 pytest
-asynctest
 pytest-operator
 pytest-order
 pytest-sugar

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,0 @@
-pytest
-pytest-operator
-pytest-order
-pytest-sugar
-pytest-asyncio
-juju

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,7 @@
+pytest
+asynctest
+pytest-operator
+pytest-order
+pytest-sugar
+pytest-asyncio
+juju

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,8 @@
-bcrypt
 cosl
 juju
-ops == 2.5.0 # Revert when https://github.com/canonical/operator/issues/984 is fixed.
-ops-lib-pgsql >= 1.4
-pydantic < 2 # Pinned due to cos-agent lib specifying this requirement see lib/charms/grafana_agent/v0/cos_agent.py PY_DEPS
+ops
+ops-lib-pgsql
 pytest
 pytest_asyncio
-pytest-operator
-pytest-order
-pytest-sugar
-requests == 2.28.1
-responses == 0.21.0
+requests
+responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,19 @@ ops == 2.5.0 # Revert when https://github.com/canonical/operator/issues/984 is f
 ops-lib-pgsql >= 1.4
 requests == 2.28.1
 responses == 0.21.0
+pytest_asyncio
+ops >= 2.0.0
+ops-lib-pgsql
+bcrypt
+# Pinned due to cos-agent lib specifying this requirement see lib/charms/grafana_agent/v0/cos_agent.py PY_DEPS
+pydantic < 2
+cosl
+# Due to https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+macaroonbakery == 1.3.2
+pytest
+asynctest
+pytest-operator
+pytest-order
+pytest-sugar
+pytest-asyncio
+juju

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,6 @@ bcrypt
 # Pinned due to cos-agent lib specifying this requirement see lib/charms/grafana_agent/v0/cos_agent.py PY_DEPS
 pydantic < 2
 cosl
-# Due to https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
-macaroonbakery == 1.3.2
 pytest
 asynctest
 pytest-operator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,11 @@
-asynctest
 bcrypt
 cosl
 juju
 ops == 2.5.0 # Revert when https://github.com/canonical/operator/issues/984 is fixed.
-ops-lib-pgsql
 ops-lib-pgsql >= 1.4
 pydantic < 2 # Pinned due to cos-agent lib specifying this requirement see lib/charms/grafana_agent/v0/cos_agent.py PY_DEPS
 pytest
 pytest_asyncio
-pytest-asyncio
 pytest-operator
 pytest-order
 pytest-sugar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 cosl
-juju
 ops
 ops-lib-pgsql
-pytest
-pytest_asyncio
 requests
 responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,16 @@
-ops == 2.5.0 # Revert when https://github.com/canonical/operator/issues/984 is fixed.
-ops-lib-pgsql >= 1.4
-requests == 2.28.1
-responses == 0.21.0
-pytest_asyncio
-ops >= 2.0.0
-ops-lib-pgsql
-bcrypt
-# Pinned due to cos-agent lib specifying this requirement see lib/charms/grafana_agent/v0/cos_agent.py PY_DEPS
-pydantic < 2
-cosl
-pytest
 asynctest
+bcrypt
+cosl
+juju
+ops == 2.5.0 # Revert when https://github.com/canonical/operator/issues/984 is fixed.
+ops-lib-pgsql
+ops-lib-pgsql >= 1.4
+pydantic < 2 # Pinned due to cos-agent lib specifying this requirement see lib/charms/grafana_agent/v0/cos_agent.py PY_DEPS
+pytest
+pytest_asyncio
+pytest-asyncio
 pytest-operator
 pytest-order
 pytest-sugar
-pytest-asyncio
-juju
+requests == 2.28.1
+responses == 0.21.0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 if [ -z "$VIRTUAL_ENV"] && [-d venv/ ]; then

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,7 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-if [ -z "$VIRTUAL_ENV"] && [-d venv/ ]; then
+if [ -z "$VIRTUAL_ENV" ] && [ -d venv/ ]; then
     . venv/bin/activate
 fi
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-if [ -z "$VIRTUAL_ENV" -a -d venv/ ]; then
+if [ -z "$VIRTUAL_ENV"] && [-d venv/ ]; then
     . venv/bin/activate
 fi
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,8 +2,11 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+# shellcheck disable=SC1091
+dir_root=$(dirname "$(readlink -f "$0")")
+
 if [ -z "$VIRTUAL_ENV" ] && [ -d venv/ ]; then
-    . venv/bin/activate
+    . "$dir_root/venv/bin/activate"
 fi
 
 if [ -z "$PYTHONPATH" ]; then

--- a/src/charm.py
+++ b/src/charm.py
@@ -535,7 +535,7 @@ class LivepatchCharm(CharmBase):
             return
 
         contract_token = event.params.get("contract-token", "")
-        if contract_token == "":
+        if not contract_token:
             event.set_results({"error": "cannot fetch the resource token: no contract token provided"})
             return
         proxies = utils.get_proxy_dict(self.config)

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Learn more at: https://juju.is/docs/sdk

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 

--- a/src/state.py
+++ b/src/state.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Manager for handling charm state."""

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Utils module."""

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,7 +6,7 @@
 import csv
 import json
 import os
-import subprocess
+import platform
 import typing as t
 
 import requests
@@ -71,6 +71,7 @@ def get_machine_token(contract_token: str, contracts_url=DEFAULT_CONTRACTS_URL, 
             url=f"{contracts_url}/v1/context/machines/token",
             data=json.dumps(payload),
             headers=headers,
+            timeout=60,
         )
         data = response.json()
         return data.get("machineToken", "")
@@ -92,6 +93,7 @@ def get_resource_token(machine_token, contracts_url=DEFAULT_CONTRACTS_URL, proxi
         req = requests.get(
             url=f"{contracts_url}/v1/resources/{RESOURCE_NAME}/context/machines/livepatch-onprem",
             headers=headers,
+            timeout=60,
         )
         data = req.json()
         return data.get("resourceToken", "")
@@ -109,12 +111,6 @@ def get_system_information() -> dict:
         for row in reader:
             if row:
                 system_information[row[0].lower()] = row[1]
-    system_information["kernel-version"] = run_uname("-r")
-    system_information["architecture"] = run_uname("-m")
+    system_information["kernel-version"] = platform.uname().release
+    system_information["architecture"] = platform.machine()
     return system_information
-
-
-def run_uname(flag) -> str:
-    """Run uname command with the given flag."""
-    result = subprocess.check_output(["uname", flag])
-    return result.decode("utf-8").strip()

--- a/src/utils.py
+++ b/src/utils.py
@@ -62,10 +62,15 @@ def get_machine_token(contract_token: str, contracts_url=DEFAULT_CONTRACTS_URL, 
         },
     }
 
-    headers = {"Authorization": "Bearer {}".format(contract_token), "Content-Type": "application/json"}
+    headers = {
+        "Authorization": f"Bearer {contract_token}",
+        "Content-Type": "application/json",
+    }
     try:
         response = requests.post(
-            url="{}/v1/context/machines/token".format(contracts_url), data=json.dumps(payload), headers=headers
+            url=f"{contracts_url}/v1/context/machines/token",
+            data=json.dumps(payload),
+            headers=headers,
         )
         data = response.json()
         return data.get("machineToken", "")
@@ -82,10 +87,10 @@ def get_resource_token(machine_token, contracts_url=DEFAULT_CONTRACTS_URL, proxi
         os.environ["https_proxy"] = proxies.get("https_proxy", "")
         os.environ["no_proxy"] = proxies.get("no_proxy", "")
 
-    headers = {"Authorization": "Bearer {}".format(machine_token)}
+    headers = {"Authorization": f"Bearer {machine_token}"}
     try:
         req = requests.get(
-            url="{}/v1/resources/{}/context/machines/livepatch-onprem".format(contracts_url, RESOURCE_NAME),
+            url=f"{contracts_url}/v1/resources/{RESOURCE_NAME}/context/machines/livepatch-onprem",
             headers=headers,
         )
         data = req.json()

--- a/tests/integration/charm_utils.py
+++ b/tests/integration/charm_utils.py
@@ -26,6 +26,7 @@ async def fetch_charm(ops_test: OpsTest) -> str:
 
 
 def get_local_charm():
+    """Search for an already built charm to save time."""
     charm = glob.glob("./*.charm")
     if len(charm) != 1:
         raise FileNotFoundError(f"Found {len(charm)} file(s) with .charm extension.")

--- a/tests/integration/charm_utils.py
+++ b/tests/integration/charm_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import glob

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.skip_if_deployed
 @pytest_asyncio.fixture(name="deploy", scope="module")
 async def app(ops_test: OpsTest):
+    """Build and deploy the app and its components."""
     logger.info("Building local charm")
     charm = await fetch_charm(ops_test)
     jammy = "ubuntu@22.04"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.skip_if_deployed
 @pytest_asyncio.fixture(name="deploy", scope="module")
-async def app(ops_test: OpsTest):
+async def deploy(ops_test: OpsTest):
     """Build and deploy the app and its components."""
     logger.info("Building local charm")
     charm = await fetch_charm(ops_test)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import logging

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 class TestDeployment:
     """A wrapper class for deployment tests"""
 
+    @pytest.mark.skip("Pass until the action that uploads the oci images as artifacts in the server is merged.")
     async def test_application_is_up(self, ops_test: OpsTest):
         """The app is up and running."""
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.usefixtures("app")
+@pytest.mark.usefixtures("deploy")
 class TestDeployment:
     """A wrapper class for deployment tests"""
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("app")
 class TestDeployment:
+    """A wrapper class for deployment tests"""
+
     async def test_application_is_up(self, ops_test: OpsTest):
         """The app is up and running."""
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import logging

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import ops.testing

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -57,8 +57,8 @@ class TestCharm(unittest.TestCase):
             self.tempdir = tempdir
             self.harness.charm.framework.charm_dir = pathlib.Path(self.tempdir)
 
-        self.harness.container_pebble_ready("livepatch")
-        self.harness.container_pebble_ready("livepatch-schema-upgrade")
+        # self.harness.container_pebble_ready("livepatch")
+        # self.harness.container_pebble_ready("livepatch-schema-upgrade")
 
     def test_on_config_changed(self):
         """A test for config changed hook."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Learn more about testing at: https://juju.is/docs/sdk/testing

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -52,18 +52,13 @@ class TestCharm(unittest.TestCase):
         self.harness.add_oci_resource("livepatch-server-image")
         self.harness.add_oci_resource("livepatch-schema-upgrade-tool-image")
         self.harness.begin()
-
-        with tempfile.TemporaryDirectory() as tempdir:
-            self.tempdir = tempdir
-            self.harness.charm.framework.charm_dir = pathlib.Path(self.tempdir)
-
-        # self.harness.container_pebble_ready("livepatch")
-        # self.harness.container_pebble_ready("livepatch-schema-upgrade")
+        rel_id = self.harness.add_relation("livepatch", "livepatch")
+        self.harness.add_relation_unit(rel_id, f"{APP_NAME}/1")
+        self.harness.container_pebble_ready("livepatch")
+        self.harness.container_pebble_ready("livepatch-schema-upgrade")
 
     def test_on_config_changed(self):
         """A test for config changed hook."""
-        rel_id = self.harness.add_relation("livepatch", "livepatch")
-        self.harness.add_relation_unit(rel_id, f"{APP_NAME}/1")
         self.harness.set_leader(True)
 
         self.harness.charm._state.dsn = "postgres://123"
@@ -103,8 +98,6 @@ class TestCharm(unittest.TestCase):
 
     def test_missing_url_template_config_causes_blocked_state(self):
         """A test for missing url template."""
-        rel_id = self.harness.add_relation("livepatch", "livepatch")
-        self.harness.add_relation_unit(rel_id, f"{APP_NAME}/1")
         self.harness.set_leader(True)
 
         self.harness.charm._state.dsn = "postgres://123"
@@ -137,8 +130,6 @@ class TestCharm(unittest.TestCase):
 
     def test_missing_sync_token_causes_blocked_state(self):
         """For on-prem servers, a missing sync token should cause a blocked state."""
-        rel_id = self.harness.add_relation("livepatch", "livepatch")
-        self.harness.add_relation_unit(rel_id, f"{APP_NAME}/1")
         self.harness.set_leader(True)
 
         self.harness.charm._state.dsn = "postgres://123"
@@ -174,9 +165,6 @@ class TestCharm(unittest.TestCase):
 
     def test_logrotate_config_pushed(self):
         """assure that logrotate config is pushed."""
-        rel_id = self.harness.add_relation("livepatch", "livepatch")
-        self.harness.add_relation_unit(rel_id, "canonical-livepatch-server-k8s/1")
-
         # Trigger config-changed so that logrotate config gets written
         self.harness.charm.on.config_changed.emit()
 
@@ -187,8 +175,6 @@ class TestCharm(unittest.TestCase):
 
     def test_database_relations_are_mutually_exclusive__legacy_first(self):
         """ "assure that database relations are mutually exclusive."""
-        rel_id = self.harness.add_relation("livepatch", "livepatch")
-        self.harness.add_relation_unit(rel_id, f"{APP_NAME}/1")
         self.harness.set_leader(True)
         self.harness.enable_hooks()
 
@@ -221,8 +207,6 @@ class TestCharm(unittest.TestCase):
 
     def test_database_relations_are_mutually_exclusive__standard_first(self):
         """ "assure that database relations are mutually exclusive."""
-        rel_id = self.harness.add_relation("livepatch", "livepatch")
-        self.harness.add_relation_unit(rel_id, f"{APP_NAME}/1")
         self.harness.set_leader(True)
         self.harness.enable_hooks()
 
@@ -255,8 +239,6 @@ class TestCharm(unittest.TestCase):
 
     def test_postgres_patch_storage_config_sets_in_container(self):
         """A test for postgres patch storage config in container."""
-        rel_id = self.harness.add_relation("livepatch", "livepatch")
-        self.harness.add_relation_unit(rel_id, f"{APP_NAME}/1")
         self.harness.set_leader(True)
 
         self.harness.charm._state.dsn = "postgres://123"
@@ -291,8 +273,6 @@ class TestCharm(unittest.TestCase):
 
     def test_postgres_patch_storage_config_defaults_to_database_relation(self):
         """A test for postgres patch storage config."""
-        rel_id = self.harness.add_relation("livepatch", "livepatch")
-        self.harness.add_relation_unit(rel_id, f"{APP_NAME}/1")
         self.harness.set_leader(True)
         self.harness.enable_hooks()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,8 +3,6 @@
 
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
-import pathlib
-import tempfile
 import unittest
 from unittest.mock import patch
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -15,6 +15,8 @@ from src.charm import LivepatchCharm
 
 APP_NAME = "canonical-livepatch-server-k8s"
 
+TEST_TOKEN = "test-token"  # nosec
+
 
 class MockOutput:
     """A wrapper class for command output and errors."""
@@ -66,7 +68,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
 
         self.harness.charm._state.dsn = "postgres://123"
-        self.harness.charm._state.resource_token = "test-token"
+        self.harness.charm._state.resource_token = TEST_TOKEN
 
         container = self.harness.model.unit.get_container("livepatch")
         with patch("src.charm.LivepatchCharm.migration_is_required") as migration:
@@ -107,7 +109,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
 
         self.harness.charm._state.dsn = "postgres://123"
-        self.harness.charm._state.resource_token = "test-token"
+        self.harness.charm._state.resource_token = TEST_TOKEN
 
         container = self.harness.model.unit.get_container("livepatch")
         with patch("src.charm.LivepatchCharm.migration_is_required") as migration:
@@ -259,7 +261,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
 
         self.harness.charm._state.dsn = "postgres://123"
-        self.harness.charm._state.resource_token = "test-token"
+        self.harness.charm._state.resource_token = TEST_TOKEN
 
         container = self.harness.model.unit.get_container("livepatch")
         with patch("src.charm.LivepatchCharm.migration_is_required") as migration:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -24,7 +24,7 @@ class MockOutput:
         self._stderr = stderr
 
     def wait_output(self):
-        """return the stdout and stderr from running the command."""
+        """Return the stdout and stderr from running the command."""
         return self._stdout, self._stderr
 
 
@@ -162,7 +162,7 @@ class TestCharm(unittest.TestCase):
         )
 
     def test_logrotate_config_pushed(self):
-        """assure that logrotate config is pushed."""
+        """Assure that logrotate config is pushed."""
         # Trigger config-changed so that logrotate config gets written
         self.harness.charm.on.config_changed.emit()
 
@@ -172,7 +172,7 @@ class TestCharm(unittest.TestCase):
         self.assertIn("/var/log/livepatch {", config)
 
     def test_database_relations_are_mutually_exclusive__legacy_first(self):
-        """ "assure that database relations are mutually exclusive."""
+        """Assure that database relations are mutually exclusive."""
         self.harness.set_leader(True)
         self.harness.enable_hooks()
 
@@ -204,7 +204,7 @@ class TestCharm(unittest.TestCase):
         )
 
     def test_database_relations_are_mutually_exclusive__standard_first(self):
-        """ "assure that database relations are mutually exclusive."""
+        """Assure that database relations are mutually exclusive."""
         self.harness.set_leader(True)
         self.harness.enable_hooks()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -55,8 +55,7 @@ class TestCharm(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tempdir:
             self.tempdir = tempdir
-            self.addCleanup(self.tempdir.cleanup)
-            self.harness.charm.framework.charm_dir = pathlib.Path(self.tempdir.name)
+            self.harness.charm.framework.charm_dir = pathlib.Path(self.tempdir)
 
         self.harness.container_pebble_ready("livepatch")
         self.harness.container_pebble_ready("livepatch-schema-upgrade")

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     pflake8 --config {toxinidir}/pyproject.toml {[vars]all_path}
     mypy {[vars]all_path} --ignore-missing-imports --follow-imports=skip --install-types --non-interactive --exclude {toxinidir}/lib/*
-    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,E1121,R0801,E1120,W0511,C0415
+    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0103,R0913,C0301,W0212,R0902,C0104,E1121,R0801,E1120,W0511,C0415,C0114
 
 [testenv:coverage-report]
 description = Create test coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,9 @@ deps =
     pytest
     coverage[toml]
     jinja2
+    juju
+    pytest
+    pytest_asyncio
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-skipsdist=True
+skipsdist = True
 skip_missing_interpreters = True
 envlist = fmt, lint, unit, static, coverage-report
-max-line-length=120
+max-line-length = 120
 
 [isort]
 profile = black
@@ -88,17 +88,19 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-        -m pytest --ignore={[vars]tst_path}unit -v {posargs}
+        -m pytest --ignore={[vars]tst_path}integration -v {posargs}
     coverage report
+
+
 
 [testenv:integration]
 description = Run integration tests
 deps =
     pytest
-    juju~=2.9
+    juju~=3.2
     pytest-operator
     pytest-asyncio
     requests
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}integration --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
This PR started as a way to introduce a workflow that can download the two docker OCIs artifacts that were uploaded by the livepatch-server release charm action, and then proceeds to upload the charm to charmhub; however, it quickly turned into a refactoring PR as the github actions that were enforced by the operator-workflow inherited actions blocked the merge.

refactoring includes: 
- eliminate the need to run uname commands by switching over to the built-in platform module. Thus, removing the need to use `subprocess`, which introduced some security risks as noted by bandit in the static analysis step I added in an earlier PR.
- refactor the largest function which had +150 lines of code into some smaller reusable functions so that the complexity linter and the branches-count and return-statement-count are no longer failing. 
- Unit tests were failing as the container_pebble_ready was trying to get_relations; however, the relations were created in individual tests rather than in the setup function, which resulted in the code accessing the relation on a NoneType (hence the failure). 


Notes:
- I marked the integration test as skippable with a reason. The problem was that the charm originally was in the same repo with the server-oci and the schema-upgrade-oci images, but this is no longer the case. Thus, the resources are simply not available to be used in the deployment fixture added in my earlier PR #1. 

I added a github action to this repo that would try to download these 2 as artifacts from the livepatch server repo. 
https://github.com/canonical/livepatch-server/pull/1077 

so please take a look at the above PR as it is needed for this repo


