### PR TITLE
Uses run_id instead of artifact_id for cross-repo downloads

### DIFF
--- a/.github/workflows/release_charm.yaml
+++ b/.github/workflows/release_charm.yaml
@@ -3,7 +3,7 @@ name: Upload charm
 on:
   workflow_dispatch:
     inputs:
-      artifact_id:
+      run_id:
         type: number
         required: true
 
@@ -16,12 +16,17 @@ jobs:
         with:
           repository: canonical/livepatch-server
           github-token: "${{ secrets.GH_PAT }}"
+          run-id: ${{ inputs.run_id }}
+          merge-multiple: true
 
       - name: load images into local docker registry
         run: |
-          echo "artifact_id: ${{ inputs.artifact_id }}"
           ls -la
-          tar -xzvf artifact.zip 
+          if [ -f artifact.zip ]; then
+              tar -xzvf artifact.zip
+          else
+              echo "artifact.zip file is automatically extracted."
+          fi
           docker load -i livepatch-server.tar
           docker load -i schema-tool.tar
 


### PR DESCRIPTION
without the run_id, the download_action cannot see the artifacts. 

I am testing this workflow by dispatching it manually until it works, and then I will update the automatic dispatcher in the livepatch server accordingly, so bear with me, it is a painful debugging process