### PR TITLE
Fix invalid charmcraft yaml

### DIFF
--- a/.github/workflows/release_charm.yaml
+++ b/.github/workflows/release_charm.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: canonical/charming-actions/upload-charm@main
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          github-token: "${{ secrets.GH_PAT }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "latest/edge"
           pull-image: "false"
           tag-prefix: "k8s"

--- a/.github/workflows/release_charm.yaml
+++ b/.github/workflows/release_charm.yaml
@@ -19,8 +19,7 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.GH_PAT }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/canonical/livepatch-server/actions/artifacts/${{ inputs.artifact_id }}/zip --output artifact.zip
-          ls -la
-          tar -xzvf artifact.zip
+          unzip artifact.zip
           docker load -i livepatch-server.tar
           docker load -i schema-tool.tar
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,18 +4,19 @@
 # Learn more about charmcraft.yaml configuration at:
 # https://juju.is/docs/sdk/charmcraft-config
 type: "charm"
-# Note that ops 2.0 requires Python 3.8+ which is only shipped on Ubuntu 20.04 and above.
 bases:
   - build-on:
-    - name: "ubuntu"
-      channel: "20.04"
-    - name: "ubuntu"
-      channel: "22.04"
+      - name: "ubuntu"
+        channel: "20.04"
     run-on:
-    - name: "ubuntu"
-      channel: "20.04"
-    - name: "ubuntu"
-      channel: "22.04"
+      - name: "ubuntu"
+        channel: "20.04"
+  - build-on:
+      - name: "ubuntu"
+        channel: "22.04"
+    run-on:
+      - name: "ubuntu"
+        channel: "22.04"
 parts:
   charm:
     charm-python-packages: [setuptools, pip]


### PR DESCRIPTION
We had an invalid charmcraft.yaml file that broke the charmcraft pack command

Note:
This is also a perfectly valid charmcraft.yaml file that we can use to enable building our charms for other architectures, which would be really good. I left it out intentionally to not slow down charmcraft pack,  if you think we need it, I can update the PR.
```
type: charm
bases:
  - build-on:
    - name: ubuntu
      channel: "22.04"
    run-on:
    - name: "ubuntu"
      channel: "22.04"
      architectures: [amd64, arm64, ppc64el, s390x]
    - name: "ubuntu"
      channel: "23.10"
      architectures: [amd64, arm64, ppc64el, s390x]
    - name: "ubuntu"
      channel: "23.04"
      architectures: [amd64, arm64, ppc64el, s390x]
    - name: "ubuntu"
      channel: "20.04"
      architectures: [amd64, arm64, ppc64el, s390x]
```