### PR TITLE
Remove tag prefix from upload-charm workflow

### DIFF
--- a/.github/workflows/release_charm.yaml
+++ b/.github/workflows/release_charm.yaml
@@ -30,4 +30,3 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "latest/edge"
           pull-image: "false"
-          tag-prefix: "k8s"


### PR DESCRIPTION
Remove the `tag-prefix` from the upload-charm job. This was needed when multiple charms were located in the same repo. The tag prefix ensures that releases of the charm create a tag with the desired prefix but this causes issues with other workflows like the `promote-charm` [workflow](https://github.com/canonical/livepatch-k8s-operator/actions/runs/7812596629/job/21309953527) which does not accept a `tag-prefix` config option.