### PR TITLE
CSS-8020 - Add Grafana Dashboard to charm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,27 +3,16 @@
 
 .PHONY: microk8s-push operator-prod-k8s deploy-onprem-k8s
 
-# Re-tag and push to microk8s for testing locally
-# Note: When pushing, should share many layers between each other
-microk8s-push: docker-prod docker-admin-tool docker-schema-tool
-	docker tag livepatch 			    localhost:32000/livepatch-server:latest
-	docker tag livepatch-schema-tool 	localhost:32000/livepatch-schema-tool:latest
-	docker tag livepatch-admin-tool 	localhost:32000/livepatch-admin-tool:latest
-
-	docker push localhost:32000/livepatch-server:latest
-	docker push localhost:32000/livepatch-schema-tool:latest
-	docker push localhost:32000/livepatch-admin-tool:latest
-
 # Builds the prod operator charm, can be used with hosted or onprem images
 operator-prod-k8s:
 	rm -f *.charm
-	sudo -E charmcraft pack -p ./charms/operator-k8s
+	charmcraft pack
 
 
 # NOTE: For local use only
 # Requires the schema-tool (docker-schema-tool), livepatch prod (docker), and charm (operator-prod-k8s) to be run first.
 deploy-onprem-k8s: operator-prod-k8s microk8s-push
-	juju deploy ./livepatch_ubuntu-20.04-amd64.charm \
+	juju deploy ./canonical-livepatch-server-k8s_ubuntu-20.04-amd64_ubuntu-22.04-amd64.charm \
 		--resource livepatch-schema-upgrade-tool-image=localhost:32000/livepatch-schema-tool:latest \
-		--resource livepatch-server-image=localhost:32000/livepatch-onprem:latest
+		--resource livepatch-server-image=localhost:32000/livepatch-server:latest
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -39,7 +39,6 @@ ON_PREM_REQUIRED_SETTINGS: t.Dict[str, str] = {}
 
 class DeferError(Exception):
     """An exception that indicates the event should be deferred."""
-    pass
 
 
 class LivepatchCharm(CharmBase):

--- a/src/charm.py
+++ b/src/charm.py
@@ -37,6 +37,11 @@ REQUIRED_SETTINGS = {
 ON_PREM_REQUIRED_SETTINGS: t.Dict[str, str] = {}
 
 
+class DeferError(Exception):
+    """An exception that indicates the event should be deferred."""
+    pass
+
+
 class LivepatchCharm(CharmBase):
     """The livepatch k8s charm."""
 
@@ -108,13 +113,6 @@ class LivepatchCharm(CharmBase):
         # Grafana dashboard relation
         self._grafana_dashboards = GrafanaDashboardProvider(self, relation_name="grafana-dashboard")
 
-    def check_ready_state_and_defer(self, event):
-        """Check that the state is ready, and if not, defer the event."""
-        if not self._state.is_ready():
-            event.defer()
-            LOGGER.warning("State is not ready")
-            return
-
     def on_config_changed(self, event):
         """On config changed hook, which runs first."""
         self._update_workload_container_config(event)
@@ -160,29 +158,22 @@ class LivepatchCharm(CharmBase):
         if not dsn:
             LOGGER.info("waiting for PG connection string")
             self.unit.status = BlockedStatus("Waiting for postgres relation to be established.")
-            event.defer()
-            return
+            raise DeferError()
 
         schema_container = self.unit.get_container(SCHEMA_UPGRADE_CONTAINER)
         if not schema_container.can_connect():
             LOGGER.error("cannot connect to the schema update container")
             self.unit.status = WaitingStatus("Waiting to connect - schema container.")
-            event.defer()
-            return
+            raise DeferError
 
         upgrade_required = False
         try:
             upgrade_required = self.migration_is_required(schema_container, dsn)
         except Exception as e:
             LOGGER.error(f"Failed to determe if schema upgrade required: {e}")
-            self.unit.status = WaitingStatus("Unable to determine database readiness")
-            event.defer()
-            return
 
         if upgrade_required:
             self.schema_upgrade(schema_container, dsn)
-
-        return
 
     def get_env_vars(self) -> dict:
         """Map config to env vars and return a processed dict."""
@@ -209,12 +200,20 @@ class LivepatchCharm(CharmBase):
 
     def _update_workload_container_config(self, event):
         """Update workload with all available configuration data."""
-        self.check_ready_state_and_defer(event)
+        if not self._state.is_ready():
+            event.defer()
+            LOGGER.warning("State is not ready")
+            return
 
         # Quickly update logrotates config each workload update
         self._push_to_workload(LOGROTATE_CONFIG_PATH, self._get_logrotate_config(), event)
 
-        self.handle_schema_upgrade(event)
+        try:
+            self.handle_schema_upgrade(event)
+        except DeferError:
+            event.defer()
+            return
+
         # This token comes from an action rather than config so we check for it specifically.
         if not self.config.get("server.is-hosted"):
             if self._state.resource_token is None or self._state.resource_token:
@@ -295,7 +294,10 @@ class LivepatchCharm(CharmBase):
 
         once setup is complete a primary/standby may join / change in consequent events.
         """
-        self.check_ready_state_and_defer(event)
+        if not self._state.is_ready():
+            event.defer()
+            LOGGER.warning("State is not ready")
+            return
 
         LOGGER.info("(postgresql, legacy database relation) RELATION_JOINED event fired.")
 
@@ -320,7 +322,10 @@ class LivepatchCharm(CharmBase):
 
         The internal snap configuration is updated to reflect this.
         """
-        self.check_ready_state_and_defer(event)
+        if not self._state.is_ready():
+            event.defer()
+            LOGGER.warning("State is not ready")
+            return
 
         LOGGER.info("(postgresql, legacy database relation) MASTER_CHANGED event fired.")
 
@@ -371,7 +376,10 @@ class LivepatchCharm(CharmBase):
 
         LOGGER.info("(postgresql) RELATION_JOINED event fired.")
 
-        self.check_ready_state_and_defer(event)
+        if not self._state.is_ready():
+            event.defer()
+            LOGGER.warning("State is not ready")
+            return
 
         if self._is_legacy_database_relation_activated():
             LOGGER.error(f"The `{DATABASE_RELATION_LEGACY}` relation is already integrated.")
@@ -418,7 +426,10 @@ class LivepatchCharm(CharmBase):
 
     def schema_upgrade_action(self, event):
         """Run the schema upgrade action."""
-        self.check_ready_state_and_defer(event)
+        if not self._state.is_ready():
+            event.defer()
+            LOGGER.warning("State is not ready")
+            return
 
         db_uri = self._state.dsn
         container = self.unit.get_container(SCHEMA_UPGRADE_CONTAINER)
@@ -473,7 +484,10 @@ class LivepatchCharm(CharmBase):
 
     def schema_version_check_action(self, event):
         """Check schema version action."""
-        self.check_ready_state_and_defer(event)
+        if not self._state.is_ready():
+            event.defer()
+            LOGGER.warning("State is not ready")
+            return
 
         db_uri = self._state.dsn
         container = self.unit.get_container(SCHEMA_UPGRADE_CONTAINER)

--- a/src/grafana_dashboards/livepatch-metrics.json
+++ b/src/grafana_dashboards/livepatch-metrics.json
@@ -433,7 +433,7 @@
             "editorMode": "code",
             "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{}[$__rate_interval])) by (handler, method, code) ",
             "interval": "",
-            "intervalFactor": 10,
+            "intervalFactor": 1,
             "legendFormat": "{{code}} - {{handler}} - {{method}}",
             "range": true,
             "refId": "A"

--- a/src/grafana_dashboards/livepatch-metrics.json
+++ b/src/grafana_dashboards/livepatch-metrics.json
@@ -1,0 +1,2272 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 5,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "collapsed": false,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 32,
+        "panels": [],
+        "targets": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "refId": "A"
+          }
+        ],
+        "title": "General",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "blue",
+              "mode": "fixed"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 4,
+          "x": 0,
+          "y": 1
+        },
+        "id": 23,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "vertical",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.5.3",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", code=\"200\"}[$__rate_interval])) by (code)",
+            "interval": "",
+            "legendFormat": "{{code}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "HTTP 200 [10m]",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 1000
+                },
+                {
+                  "color": "orange",
+                  "value": 5000
+                },
+                {
+                  "color": "red",
+                  "value": 5001
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 4,
+          "x": 5,
+          "y": 1
+        },
+        "id": 24,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "vertical",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.5.3",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", code=\"204\"}[$__rate_interval])) by (code)",
+            "interval": "",
+            "legendFormat": "{{code}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "HTTP 204 [10m]",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 4,
+          "x": 10,
+          "y": 1
+        },
+        "id": 25,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "vertical",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.5.3",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", code=\"401\"}[$__rate_interval])) by (code)",
+            "interval": "",
+            "legendFormat": "{{code}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "HTTP 401 [10m]",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 100
+                },
+                {
+                  "color": "red",
+                  "value": 111
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 4,
+          "x": 15,
+          "y": 1
+        },
+        "id": 26,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "vertical",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.5.3",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", code=\"403\"}[$__rate_interval])) by (code)",
+            "interval": "",
+            "legendFormat": "{{code}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "HTTP 403 [10m]",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 1000
+                },
+                {
+                  "color": "orange",
+                  "value": 5000
+                },
+                {
+                  "color": "red",
+                  "value": 5001
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 4,
+          "x": 20,
+          "y": 1
+        },
+        "id": 27,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "vertical",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "9.5.3",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", code=\"404\"}[$__rate_interval])) by (code)",
+            "interval": "",
+            "legendFormat": "{{code}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "HTTP 404 [10m]",
+        "type": "stat"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 6
+        },
+        "hiddenSeries": false,
+        "id": 34,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": true,
+          "min": true,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (handler, method, code) ",
+            "interval": "",
+            "intervalFactor": 10,
+            "legendFormat": "{{code}} - {{handler}} - {{method}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Livepatch Requests Per Second",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": true,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Value"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "DB Errors"
+                }
+              ]
+            }
+          ]
+        },
+        "fill": 5,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 14
+        },
+        "hiddenSeries": false,
+        "id": 19,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": false,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "DB Errors",
+            "color": "#E02F44"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(livepatch_server_database_error_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
+            "interval": "",
+            "legendFormat": "",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [
+          {
+            "colorMode": "critical",
+            "fill": true,
+            "line": true,
+            "op": "gt",
+            "value": 1000,
+            "yaxis": "left"
+          }
+        ],
+        "timeRegions": [],
+        "title": "Increase In Database Errors [10m]",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "collapsed": false,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 22
+        },
+        "id": 9,
+        "panels": [],
+        "targets": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "refId": "A"
+          }
+        ],
+        "title": "Client Requests",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "description": "Displays the 95th percentile of requests handled under the the Y axis(in seconds).",
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "{handler=\"/v1/client/:id\"}"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Register/Deregister Client (/v1/client/id)"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "{handler=\"/v1/client/:id/info\"}"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Client Info (/v1/client/:id/info)"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "{handler=\"/v1/client/:id/updates\"}"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Client Status Report (/v1/client/:id/updates)"
+                }
+              ]
+            }
+          ]
+        },
+        "fill": 5,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 10,
+          "w": 12,
+          "x": 0,
+          "y": 23
+        },
+        "hiddenSeries": false,
+        "id": 5,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "hideEmpty": false,
+          "hideZero": false,
+          "max": true,
+          "min": false,
+          "rightSide": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_http_request_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", handler=~\"/v1/client/.*\"}[$__rate_interval]\n        )\n    ) by (le, handler,code)\n)",
+            "interval": "",
+            "legendFormat": "",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [
+          {
+            "colorMode": "critical",
+            "fill": true,
+            "line": true,
+            "op": "gt",
+            "value": 5,
+            "yaxis": "left"
+          }
+        ],
+        "timeRegions": [],
+        "title": "${Percentile}th Percentile[10m]: /v1/client Response Times",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "s",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "reqps",
+            "logBase": 1,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 5,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 10,
+          "w": 12,
+          "x": 12,
+          "y": 23
+        },
+        "hiddenSeries": false,
+        "id": 7,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": true,
+          "min": false,
+          "rightSide": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": true,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_database_query_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", method!~\"^KPI.*\"}[$__rate_interval]\n        )\n    ) by (le, method)\n)",
+            "interval": "",
+            "legendFormat": "{{method}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "${Percentile}th Percentile[10m]: DB Response Time",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "s",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "resource-token"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Contracts"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "machine-token"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Machine Token"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "auth-token"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Auth Token"
+                }
+              ]
+            }
+          ]
+        },
+        "fill": 5,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 10,
+          "w": 12,
+          "x": 0,
+          "y": 33
+        },
+        "hiddenSeries": false,
+        "id": 21,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": true,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_http_auth_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]\n        )\n    ) by (le, token_type)\n)",
+            "interval": "",
+            "legendFormat": "{{token_type}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "${Percentile}th Percentile[10m]: Auth Timings ",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "s",
+            "label": "",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 5,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 10,
+          "w": 12,
+          "x": 12,
+          "y": 33
+        },
+        "hiddenSeries": false,
+        "id": 30,
+        "legend": {
+          "alignAsTable": true,
+          "avg": false,
+          "current": true,
+          "max": true,
+          "min": false,
+          "rightSide": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": true,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_database_query_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", method=~\"^KPI.*$\"}[$__rate_interval]\n        )\n    ) by (le, method)\n)",
+            "interval": "",
+            "legendFormat": "{{method}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "${Percentile}th Percentile[10m]: DB KPI Response Time",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "s",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": true,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "description": "This graph represents how many times each token type was used over a 24h period. \nMachine tokens are used when a client authenticated with an auth token checks in.\nResource tokens are used when a client authenticated with ua-contracts checks in.\nAuth tokens are used whenever a new client is registered using old style auth tokens.\nSync tokens are used whenever an on-prem server syncs patches, on-prem servers can also sync via resource tokens.",
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 43
+        },
+        "hiddenSeries": false,
+        "id": 45,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": false,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(livepatch_server_http_authorizer_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[24h])) by (token)",
+            "format": "time_series",
+            "instant": false,
+            "interval": "86400",
+            "intervalFactor": 1,
+            "legendFormat": "{{token}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Token Usage",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "collapsed": false,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 51
+        },
+        "id": 56,
+        "panels": [],
+        "targets": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "refId": "A"
+          }
+        ],
+        "title": "Contracts Info",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "description": "Errors from the contracts service.",
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 52
+        },
+        "hiddenSeries": false,
+        "id": 54,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(livepatch_server_contracts_error_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
+            "interval": "",
+            "legendFormat": "client errors",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Contracts Errors",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "description": "Reasons why a client was reject from the contracts server.",
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 52
+        },
+        "hiddenSeries": false,
+        "id": 57,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(rate(livepatch_server_contracts_error_reported_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (code)",
+            "interval": "",
+            "legendFormat": "{{code}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Contracts Response Errors",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "collapsed": false,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 60
+        },
+        "id": 47,
+        "panels": [],
+        "targets": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "refId": "A"
+          }
+        ],
+        "title": "Cache Info - Patches",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "description": "The number of cache hits over the last 10 minutes summed over all the Livepatch server units.",
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 61
+        },
+        "hiddenSeries": false,
+        "id": 49,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(livepatch_server_patch_cache_hits{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
+            "interval": "",
+            "legendFormat": "Hits",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Patch Info Cache Hits",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "description": "The number of cache misses over the last 10 minutes summed over all the Livepatch server units.",
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 61
+        },
+        "hiddenSeries": false,
+        "id": 50,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(livepatch_server_patch_cache_misses{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
+            "interval": "",
+            "legendFormat": "Misses",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Patch Info Cache Misses",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "description": "The number of cache evictions over the last 10 minutes summed over all the Livepatch server units.",
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 69
+        },
+        "hiddenSeries": false,
+        "id": 51,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(livepatch_server_patch_cache_evictions{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
+            "interval": "",
+            "legendFormat": "Evictions",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Patch Info Cache Evictions",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "description": "The cache length on each unit",
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 69
+        },
+        "hiddenSeries": false,
+        "id": 52,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "livepatch_server_patch_cache_length{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
+            "interval": "",
+            "legendFormat": "",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Patch Info Cache Length",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "collapsed": false,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 77
+        },
+        "id": 13,
+        "panels": [],
+        "targets": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "refId": "A"
+          }
+        ],
+        "title": "Supported Kernels ",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 5,
+          "x": 0,
+          "y": 78
+        },
+        "id": 11,
+        "options": {
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true
+        },
+        "pluginVersion": "9.5.3",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(livepatch_client_updates_with_unknown_kernel_total{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[60m]))",
+            "instant": false,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "Increase[60m]: Unknown Kernel",
+        "type": "gauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 5,
+          "x": 5,
+          "y": 78
+        },
+        "id": 15,
+        "options": {
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true
+        },
+        "pluginVersion": "9.5.3",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(livepatch_logging_kernels_error_total{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[60m]))",
+            "interval": "",
+            "legendFormat": "",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Increase[60m]: Kernel Lib Errors",
+        "type": "gauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 5,
+          "x": 10,
+          "y": 78
+        },
+        "id": 17,
+        "options": {
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true
+        },
+        "pluginVersion": "9.5.3",
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(livepatch_client_updates_without_build_date_total{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[60m]))",
+            "interval": "",
+            "legendFormat": "",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Increase[60]: Missing Build Date",
+        "type": "gauge"
+      },
+      {
+        "collapsed": false,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 83
+        },
+        "id": 40,
+        "panels": [],
+        "targets": [
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "refId": "A"
+          }
+        ],
+        "title": "Test Area",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 0,
+          "y": 84
+        },
+        "hiddenSeries": false,
+        "id": 42,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_http_request_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]\n        )\n    ) by (le, handler)\n)",
+            "interval": "",
+            "legendFormat": "",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "All Endpoints Timings ${Percentile}th percentile",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "s",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheusds}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "links": []
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 12,
+          "y": 84
+        },
+        "hiddenSeries": false,
+        "id": 43,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "9.5.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "datasource": {
+              "uid": "${prometheusds}"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_database_query_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]\n        )\n    ) by (le, method)\n)",
+            "interval": "",
+            "legendFormat": "",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "All Database Timings ${Percentile}th percentile",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "s",
+            "logBase": 1,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "juju_stg-cos-lite-comsys_b8a87977-61c8-4ac7-8a66-699d8c6e4f7f_prometheus_0",
+            "value": "juju_stg-cos-lite-comsys_b8a87977-61c8-4ac7-8a66-699d8c6e4f7f_prometheus_0"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "Datasource",
+          "options": [],
+          "query": "prometheus",
+          "queryValue": "",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "current": {
+            "selected": true,
+            "text": "95",
+            "value": "95"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "Percentile",
+          "options": [
+            {
+              "selected": false,
+              "text": "50",
+              "value": "50"
+            },
+            {
+              "selected": false,
+              "text": "75",
+              "value": "75"
+            },
+            {
+              "selected": false,
+              "text": "80",
+              "value": "80"
+            },
+            {
+              "selected": false,
+              "text": "85",
+              "value": "85"
+            },
+            {
+              "selected": false,
+              "text": "90",
+              "value": "90"
+            },
+            {
+              "selected": true,
+              "text": "95",
+              "value": "95"
+            }
+          ],
+          "query": "50, 75, 80, 85, 90, 95",
+          "queryValue": "",
+          "skipUrlSync": false,
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Livepatch Metrics",
+    "uid": "a8bb1a81-646c-4baa-ab79-df2c796fcf3e",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/src/grafana_dashboards/livepatch-metrics.json
+++ b/src/grafana_dashboards/livepatch-metrics.json
@@ -100,7 +100,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", code=\"200\"}[$__rate_interval])) by (code)",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{code=\"200\"}[$__rate_interval])) by (code)",
             "interval": "",
             "legendFormat": "{{code}}",
             "range": true,
@@ -170,7 +170,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", code=\"204\"}[$__rate_interval])) by (code)",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{code=\"204\"}[$__rate_interval])) by (code)",
             "interval": "",
             "legendFormat": "{{code}}",
             "range": true,
@@ -228,7 +228,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", code=\"401\"}[$__rate_interval])) by (code)",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{code=\"401\"}[$__rate_interval])) by (code)",
             "interval": "",
             "legendFormat": "{{code}}",
             "range": true,
@@ -294,7 +294,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", code=\"403\"}[$__rate_interval])) by (code)",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{code=\"403\"}[$__rate_interval])) by (code)",
             "interval": "",
             "legendFormat": "{{code}}",
             "range": true,
@@ -364,7 +364,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", code=\"404\"}[$__rate_interval])) by (code)",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{code=\"404\"}[$__rate_interval])) by (code)",
             "interval": "",
             "legendFormat": "{{code}}",
             "range": true,
@@ -431,7 +431,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (handler, method, code) ",
+            "expr": "sum(rate(livepatch_server_http_request_duration_seconds_count{}[$__rate_interval])) by (handler, method, code) ",
             "interval": "",
             "intervalFactor": 10,
             "legendFormat": "{{code}} - {{handler}} - {{method}}",
@@ -542,7 +542,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(increase(livepatch_server_database_error_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
+            "expr": "sum(increase(livepatch_server_database_error_count{}[$__rate_interval]))",
             "interval": "",
             "legendFormat": "",
             "range": true,
@@ -711,7 +711,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_http_request_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", handler=~\"/v1/client/.*\"}[$__rate_interval]\n        )\n    ) by (le, handler,code)\n)",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_http_request_duration_seconds_bucket{handler=~\"/v1/client/.*\"}[$__rate_interval]\n        )\n    ) by (le, handler,code)\n)",
             "interval": "",
             "legendFormat": "",
             "range": true,
@@ -814,7 +814,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_database_query_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", method!~\"^KPI.*\"}[$__rate_interval]\n        )\n    ) by (le, method)\n)",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_database_query_duration_seconds_bucket{method!~\"^KPI.*\"}[$__rate_interval]\n        )\n    ) by (le, method)\n)",
             "interval": "",
             "legendFormat": "{{method}}",
             "range": true,
@@ -944,7 +944,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_http_auth_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]\n        )\n    ) by (le, token_type)\n)",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_http_auth_duration_seconds_bucket{}[$__rate_interval]\n        )\n    ) by (le, token_type)\n)",
             "interval": "",
             "legendFormat": "{{token_type}}",
             "range": true,
@@ -1039,7 +1039,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_database_query_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\", method=~\"^KPI.*$\"}[$__rate_interval]\n        )\n    ) by (le, method)\n)",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_database_query_duration_seconds_bucket{method=~\"^KPI.*$\"}[$__rate_interval]\n        )\n    ) by (le, method)\n)",
             "interval": "",
             "legendFormat": "{{method}}",
             "range": true,
@@ -1132,7 +1132,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(increase(livepatch_server_http_authorizer_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[24h])) by (token)",
+            "expr": "sum(increase(livepatch_server_http_authorizer_count{}[24h])) by (token)",
             "format": "time_series",
             "instant": false,
             "interval": "86400",
@@ -1253,7 +1253,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(increase(livepatch_server_contracts_error_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
+            "expr": "sum(increase(livepatch_server_contracts_error_count{}[$__rate_interval]))",
             "interval": "",
             "legendFormat": "client errors",
             "range": true,
@@ -1346,7 +1346,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(rate(livepatch_server_contracts_error_reported_count{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])) by (code)",
+            "expr": "sum(rate(livepatch_server_contracts_error_reported_count{}[$__rate_interval])) by (code)",
             "interval": "",
             "legendFormat": "{{code}}",
             "range": true,
@@ -1465,7 +1465,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(increase(livepatch_server_patch_cache_hits{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
+            "expr": "sum(increase(livepatch_server_patch_cache_hits{}[$__rate_interval]))",
             "interval": "",
             "legendFormat": "Hits",
             "range": true,
@@ -1558,7 +1558,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(increase(livepatch_server_patch_cache_misses{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
+            "expr": "sum(increase(livepatch_server_patch_cache_misses{}[$__rate_interval]))",
             "interval": "",
             "legendFormat": "Misses",
             "range": true,
@@ -1651,7 +1651,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(increase(livepatch_server_patch_cache_evictions{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]))",
+            "expr": "sum(increase(livepatch_server_patch_cache_evictions{}[$__rate_interval]))",
             "interval": "",
             "legendFormat": "Evictions",
             "range": true,
@@ -1744,7 +1744,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "livepatch_server_patch_cache_length{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
+            "expr": "livepatch_server_patch_cache_length{}",
             "interval": "",
             "legendFormat": "",
             "range": true,
@@ -1853,7 +1853,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(increase(livepatch_client_updates_with_unknown_kernel_total{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[60m]))",
+            "expr": "sum(increase(livepatch_client_updates_with_unknown_kernel_total{}[60m]))",
             "instant": false,
             "interval": "",
             "legendFormat": "",
@@ -1909,7 +1909,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(increase(livepatch_logging_kernels_error_total{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[60m]))",
+            "expr": "sum(increase(livepatch_logging_kernels_error_total{}[60m]))",
             "interval": "",
             "legendFormat": "",
             "range": true,
@@ -1965,7 +1965,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "sum(increase(livepatch_client_updates_without_build_date_total{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[60m]))",
+            "expr": "sum(increase(livepatch_client_updates_without_build_date_total{}[60m]))",
             "interval": "",
             "legendFormat": "",
             "range": true,
@@ -2056,7 +2056,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_http_request_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]\n        )\n    ) by (le, handler)\n)",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_http_request_duration_seconds_bucket{}[$__rate_interval]\n        )\n    ) by (le, handler)\n)",
             "interval": "",
             "legendFormat": "",
             "range": true,
@@ -2148,7 +2148,7 @@
               "uid": "${prometheusds}"
             },
             "editorMode": "code",
-            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_database_query_duration_seconds_bucket{juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\",juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]\n        )\n    ) by (le, method)\n)",
+            "expr": "histogram_quantile(\n    0.${Percentile}, \n    sum(\n        rate(\n            livepatch_server_database_query_duration_seconds_bucket{}[$__rate_interval]\n        )\n    ) by (le, method)\n)",
             "interval": "",
             "legendFormat": "",
             "range": true,

--- a/src/grafana_dashboards/temp.txt
+++ b/src/grafana_dashboards/temp.txt
@@ -1,1 +1,0 @@
-No dashboards yet.


### PR DESCRIPTION
# Description

This PR does a few things,
- Added a Grafana dashboard to the charm which matches the dashboard used to monitor hosted Livepatch. This dashboard is probably overkill for an on-prem setting but we can adjust it in the future.
- Fixed some issues in the charm that likely occurred when it was moved into a separate repo, mainly issues where we would defer an event and return but we were doing this inside a function and not indicating to the caller that the event was deferred and that we should return early.
- Cleaned up the makefile.
- Updated the Grafana dashboard relation.

The dashboard definition was tested on a locally deployed Livepatch server and COS.