### PR TITLE
Remove `series` key from `bundle.yaml`

### DIFF
--- a/bundle/bundle.yaml
+++ b/bundle/bundle.yaml
@@ -12,7 +12,6 @@ website: https://ubuntu.com/security/livepatch
 issues: https://bugs.launchpad.net/livepatch-onprem
 docs: https://discourse.ubuntu.com/t/ubuntu-livepatch-service/22723
 tags: [security]
-series: jammy
 applications:
   postgresql:
     charm: postgresql-k8s


### PR DESCRIPTION
This PR fixes the issue with the outdated `juju-bundle` application. Since the `series` key is not required, we can probably omit it.

Fixes CSS-9088