### PR TITLE
Add link to charm homepage on Discourse

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,8 +13,10 @@ description: |
   machines running on your infrastructure.
 maintainers:
   - Canonical Commercial Systems Team <jaas-crew@lists.canonical.com>
-website: https://ubuntu.com/security/livepatch
-docs: https://discourse.ubuntu.com/t/ubuntu-livepatch-service/22723
+website:
+  - https://ubuntu.com/security/livepatch
+  - https://discourse.ubuntu.com/t/ubuntu-livepatch-service/22723
+docs: https://discourse.charmhub.io/t/14366
 issues: https://bugs.launchpad.net/livepatch-onprem
 source: https://github.com/canonical/livepatch-k8s-operator
 


### PR DESCRIPTION
This PR adds the link to the Charmhub Discourse post, to be displayed as the charm homepage doc.

Fixes CSS-9105