### PR TITLE
Add step to login on GHCR when uploading bundle

### DIFF
--- a/.github/workflows/publish_bundle.yaml
+++ b/.github/workflows/publish_bundle.yaml
@@ -16,6 +16,12 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Bundle
         uses: canonical/charming-actions/upload-bundle@main
         with:


### PR DESCRIPTION
This PR adds a missing step, which is logging in on GHCR to release-bundle workflow.

Fixes CSS-9088