### PR TITLE
Add integration with airgapped contracts service

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -46,6 +46,10 @@ requires:
   database:
     interface: postgresql_client
     limit: 1 # Most charms only handle a single PostgreSQL Application.
+  pro-airgapped-server:
+    interface: livepatch-pro-airgapped-server
+    limit: 1
+    optional: true
   ingress:
     interface: ingress
   log-proxy:


### PR DESCRIPTION
This PR adds a new endpoint, named `pro-airgapped-server`, to the charm and implements the relation hooks. Unit tests are added.

Fixes CSS-9568