### PR TITLE
Add sync-tiers config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -258,6 +258,14 @@ options:
       all are synced. For example, "5.4.0" will sync "5.4.0" and up.
     type: string
     default: ""
+  patch-sync.sync-tiers:
+    description: >-
+      Mirror patch tier information from the upstream server.
+      WARNING: Enabling this feature will modify existing
+      tier information in order to match the upstream server's
+      tier structure. Avoid this if you already have tiers setup.
+    type: boolean
+    default: false
   patch-sync.proxy.enabled:
     default: false
     description: Whether or not to proxy patch syncs.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -149,6 +149,16 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.charm.unit.status.name, ActiveStatus.name)
         self.assertEqual(self.harness.charm.unit.status.message, "")
 
+    def test_container_config(self):
+        """Test specific config values match what is expected."""
+        self.harness.set_leader(True)
+        self.harness.enable_hooks()
+        self.harness.update_config({"patch-sync.sync-tiers": True})
+
+        self.start_container()
+
+        self._assert_environment_contains({"LP_PATCH_SYNC_SYNC_TIERS": True})
+
     def test_schema_upgrade_action__success(self):
         """Test the scenario where `schema-upgrade` action finishes successfully."""
         self.harness.set_leader(True)


### PR DESCRIPTION
## Description

This PR adds a config option to the charm called "sync-tiers" which will enable the sync tiers functionality.