### PR TITLE
Use `charming-actions/upload-bundle` action to promote bundle

### DIFF
--- a/.github/workflows/promote_bundle.yaml
+++ b/.github/workflows/promote_bundle.yaml
@@ -3,33 +3,31 @@ name: Promote Bundle
 on:
   workflow_dispatch:
     inputs:
-        origin-channel:
-            type: choice
-            description: 'Origin Channel'
-            options:
-            - k8s/edge
-            - k8s/beta
-            - k8s/candidate
-        destination-channel:
-            type: choice
-            description: 'Destination Channel'
-            options:
-            - k8s/beta
-            - k8s/candidate
-            - k8s/stable
+      destination-channel:
+        type: choice
+        description: 'Destination Channel'
+        options:
+          - k8s/beta
+          - k8s/candidate
+          - k8s/stable
 
 jobs:
-  promote:
+  promote-livepatch-operator-k8s-bundle:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
-    # Note the use of the release-charm action. Bundles can be treated as charms.
-    - name: Promote Bundle
-      uses: canonical/charming-actions/release-charm@main
-      with:
-        origin-channel: ${{ github.event.inputs.origin-channel }}
-        destination-channel: ${{ github.event.inputs.destination-channel }}
-        tag-prefix: "bundle"
-        charm-path: "./bundle"
-        credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Bundle
+        uses: canonical/charming-actions/upload-bundle@main
+        with:
+            credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+            tag-prefix: "bundle"
+            bundle-path: ./bundle
+            github-token: "${{ secrets.GITHUB_TOKEN }}"
+            channel: ${{ github.event.inputs.destination-channel }}


### PR DESCRIPTION
The bundle promotion workflow we had was not working. It uses the `release-charm` action which is meant to be used for charms, not bundles, because it looks for the `metadata.yaml` file. The Charmcraft CLI provides another dedicated command, `promote-bundle`, but there is no action (under `charming-action` repo) to invoke that. Although we can call it manually in our workflow, I'd rather use an action to avoid unexpected changes in the future.

In this PR I opted for an approach used by other repos, which is to use the `upload-bundle` action for both publishing (for the first time) and promotion. The action accepts a `channel` argument to upload the bundle to. The downside is that the revision number will be bumped when we promote the bundle. I'm not sure that this is the actual behaviour, but it probably is.

Fixes CSS-10960