### PR TITLE
CSS-11378/add sync token to charm config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -251,6 +251,10 @@ options:
     default: https://livepatch.canonical.com
     description: Livepatch server to download patch snapshots from.
     type: string
+  patch-sync.token:
+    description: Token generated from the admin-tool to authenticate machine to machine.
+    type: string
+    default: ""
   patch-sync.minimum-kernel-version:
     description: >-
       A minimum kernel version of format "0.0.0" denoting the lowest 

--- a/src/charm.py
+++ b/src/charm.py
@@ -200,7 +200,10 @@ class LivepatchCharm(CharmBase):
             env_vars["LP_CONTRACTS_URL"] = airgapped_pro_address
             env_vars["LP_PATCH_SYNC_ENABLED"] = False
         else:
-            env_vars["LP_PATCH_SYNC_TOKEN"] = self._state.resource_token
+            if self.config.get("patch-sync.token"):
+                env_vars["LP_PATCH_SYNC_TOKEN"] = self.config.get("patch-sync.token")
+            else:
+                env_vars["LP_PATCH_SYNC_TOKEN"] = self._state.resource_token
             if self.config.get("patch-sync.enabled") is True:
                 # TODO: Find a better way to identify a on-prem syncing instance.
                 env_vars["LP_PATCH_SYNC_ID"] = self.model.uuid
@@ -633,6 +636,11 @@ class LivepatchCharm(CharmBase):
         if not self._state.is_ready():
             LOGGER.error("cannot fetch the resource token: peer relation not ready")
             event.set_results({"error": "cannot fetch the resource token: peer relation not ready"})
+            return
+
+        if self.config.get("patch-sync.token"):
+            LOGGER.error("patch-sync.token is already set. It should be unset before setting a resource token")
+            event.set_results({"error": "patch-sync.token is already set. It should be unset before setting a resource token"})
             return
 
         contract_token = event.params.get("contract-token", "")

--- a/src/charm.py
+++ b/src/charm.py
@@ -198,11 +198,12 @@ class LivepatchCharm(CharmBase):
         if airgapped_pro_address:
             env_vars["LP_CONTRACTS_ENABLED"] = True
             env_vars["LP_CONTRACTS_URL"] = airgapped_pro_address
-            env_vars["LP_PATCH_SYNC_ENABLED"] = False
+            # if sync-token is not provided we disable the syncing in airgapped env.
+            # the sync could be enabled when chaining multiple machines in an airgapped env.
+            if not self.config.get("patch-sync.token"):
+                env_vars["LP_PATCH_SYNC_ENABLED"] = False
         else:
-            if self.config.get("patch-sync.token"):
-                env_vars["LP_PATCH_SYNC_TOKEN"] = self.config.get("patch-sync.token")
-            else:
+            if not self.config.get("patch-sync.token"):
                 env_vars["LP_PATCH_SYNC_TOKEN"] = self._state.resource_token
             if self.config.get("patch-sync.enabled") is True:
                 # TODO: Find a better way to identify a on-prem syncing instance.

--- a/src/charm.py
+++ b/src/charm.py
@@ -641,7 +641,9 @@ class LivepatchCharm(CharmBase):
 
         if self.config.get("patch-sync.token"):
             LOGGER.error("patch-sync.token is already set. It should be unset before setting a resource token")
-            event.set_results({"error": "patch-sync.token is already set. It should be unset before setting a resource token"})
+            event.set_results(
+                {"error": "patch-sync.token is already set. It should be unset before setting a resource token"}
+            )
             return
 
         contract_token = event.params.get("contract-token", "")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -957,7 +957,7 @@ class TestCharm(unittest.TestCase):
         self.harness.enable_hooks()
 
         self.harness.charm._state.dsn = "postgresql://123"
-        self.harness.charm._state.resource_token = TEST_TOKEN
+        # self.harness.charm._state.resource_token = TEST_TOKEN
 
         with patch("src.charm.LivepatchCharm.migration_is_required") as migration:
             migration.return_value = False
@@ -965,6 +965,80 @@ class TestCharm(unittest.TestCase):
                 {
                     "server.url-template": "http://localhost/{filename}",
                     "server.is-hosted": False,
+                }
+            )
+
+            pro_rel_id = self.harness.add_relation("pro-airgapped-server", "pro-airgapped-server")
+            self.harness.add_relation_unit(pro_rel_id, "pro-airgapped-server/0")
+            self.harness.update_relation_data(
+                pro_rel_id,
+                "pro-airgapped-server/0",
+                {
+                    "scheme": "scheme",
+                    "hostname": "some.host.name",
+                    "port": "9999",
+                },
+            )
+
+        self._assert_environment_contains(
+            {
+                "LP_CONTRACTS_ENABLED": True,
+                "LP_CONTRACTS_URL": "scheme://some.host.name:9999",
+            }
+        )
+
+    def test_pro_airgapped_server__sync_enabled_when_sync_token_set(self):
+        """Test pro-airgapped-server relation."""
+        self.harness.set_leader(True)
+        self.harness.enable_hooks()
+
+        self.harness.charm._state.dsn = "postgresql://123"
+
+        with patch("src.charm.LivepatchCharm.migration_is_required") as migration:
+            migration.return_value = False
+            self.harness.update_config(
+                {
+                    "server.url-template": "http://localhost/{filename}",
+                    "server.is-hosted": False,
+                    "patch-sync.enabled": True,
+                    "patch-sync.token": "AAAABBBB",
+                }
+            )
+
+            pro_rel_id = self.harness.add_relation("pro-airgapped-server", "pro-airgapped-server")
+            self.harness.add_relation_unit(pro_rel_id, "pro-airgapped-server/0")
+            self.harness.update_relation_data(
+                pro_rel_id,
+                "pro-airgapped-server/0",
+                {
+                    "scheme": "scheme",
+                    "hostname": "some.host.name",
+                    "port": "9999",
+                },
+            )
+
+        self._assert_environment_contains(
+            {
+                "LP_PATCH_SYNC_ENABLED": True,
+                "LP_CONTRACTS_ENABLED": True,
+                "LP_CONTRACTS_URL": "scheme://some.host.name:9999",
+            }
+        )
+
+    def test_pro_airgapped_server__sync_disabled_when_sync_token_not_set(self):
+        """Test pro-airgapped-server relation."""
+        self.harness.set_leader(True)
+        self.harness.enable_hooks()
+
+        self.harness.charm._state.dsn = "postgresql://123"
+
+        with patch("src.charm.LivepatchCharm.migration_is_required") as migration:
+            migration.return_value = False
+            self.harness.update_config(
+                {
+                    "server.url-template": "http://localhost/{filename}",
+                    "server.is-hosted": False,
+                    "patch-sync.enabled": True,
                 }
             )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -988,7 +988,7 @@ class TestCharm(unittest.TestCase):
         )
 
     def test_pro_airgapped_server__sync_enabled_when_sync_token_set(self):
-        """Test pro-airgapped-server relation."""
+        """Test pro-airgapped-server syncs is enabled when sync token is set."""
         self.harness.set_leader(True)
         self.harness.enable_hooks()
 
@@ -1026,7 +1026,7 @@ class TestCharm(unittest.TestCase):
         )
 
     def test_pro_airgapped_server__sync_disabled_when_sync_token_not_set(self):
-        """Test pro-airgapped-server relation."""
+        """Test pro-airgapped-server syncs is disabled when sync token is set."""
         self.harness.set_leader(True)
         self.harness.enable_hooks()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -957,7 +957,6 @@ class TestCharm(unittest.TestCase):
         self.harness.enable_hooks()
 
         self.harness.charm._state.dsn = "postgresql://123"
-        # self.harness.charm._state.resource_token = TEST_TOKEN
 
         with patch("src.charm.LivepatchCharm.migration_is_required") as migration:
             migration.return_value = False
@@ -1059,6 +1058,9 @@ class TestCharm(unittest.TestCase):
             {
                 "LP_CONTRACTS_ENABLED": True,
                 "LP_CONTRACTS_URL": "scheme://some.host.name:9999",
+            },
+            {
+                "LP_PATCH_SYNC_ENABLED": True
             }
         )
 
@@ -1068,7 +1070,6 @@ class TestCharm(unittest.TestCase):
         self.harness.enable_hooks()
 
         self.harness.charm._state.dsn = "postgresql://123"
-        self.harness.charm._state.resource_token = TEST_TOKEN
 
         with patch("src.charm.LivepatchCharm.migration_is_required") as migration:
             migration.return_value = False
@@ -1124,7 +1125,6 @@ class TestCharm(unittest.TestCase):
         self.harness.enable_hooks()
 
         self.harness.charm._state.dsn = "postgresql://123"
-        self.harness.charm._state.resource_token = TEST_TOKEN
 
         with patch("src.charm.LivepatchCharm.migration_is_required") as migration:
             migration.return_value = False

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1020,6 +1020,7 @@ class TestCharm(unittest.TestCase):
         self._assert_environment_contains(
             {
                 "LP_PATCH_SYNC_ENABLED": True,
+                "LP_PATCH_SYNC_TOKEN": "AAAABBBB",
                 "LP_CONTRACTS_ENABLED": True,
                 "LP_CONTRACTS_URL": "scheme://some.host.name:9999",
             }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -488,7 +488,10 @@ class TestCharm(unittest.TestCase):
 
         output = self.harness.run_action("get-resource-token", {"contract-token": "some-token"})
 
-        self.assertEqual(output.results, {"error": "patch-sync.token is already set. It should be unset before setting a resource token"})
+        self.assertEqual(
+            output.results,
+            {"error": "patch-sync.token is already set. It should be unset before setting a resource token"},
+        )
 
     def test_missing_url_template_config_causes_blocked_state(self):
         """A test for missing url template."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -159,6 +159,16 @@ class TestCharm(unittest.TestCase):
 
         self._assert_environment_contains({"LP_PATCH_SYNC_SYNC_TIERS": True})
 
+    def test_sync_token_set(self):
+        """Test specific config values match what is expected."""
+        self.harness.set_leader(True)
+        self.harness.enable_hooks()
+        self.harness.update_config({"patch-sync.token": "AAAABBBB"})
+
+        self.start_container()
+
+        self._assert_environment_contains({"LP_PATCH_SYNC_TOKEN": "AAAABBBB"})
+
     def test_schema_upgrade_action__success(self):
         """Test the scenario where `schema-upgrade` action finishes successfully."""
         self.harness.set_leader(True)
@@ -467,6 +477,18 @@ class TestCharm(unittest.TestCase):
         output = self.harness.run_action("get-resource-token", {"contract-token": ""})
 
         self.assertEqual(output.results, {"error": "cannot fetch the resource token: no contract token provided"})
+
+    def test_get_resource_token_action__failure__sync_token_already_set(self):
+        """Test the scenario where `get-resource-token` action fails because sync token is already set."""
+        self.harness.set_leader(True)
+        self.harness.enable_hooks()
+
+        self.start_container()
+        self.harness.update_config({"patch-sync.token": "AAAABBBB"})
+
+        output = self.harness.run_action("get-resource-token", {"contract-token": "some-token"})
+
+        self.assertEqual(output.results, {"error": "patch-sync.token is already set. It should be unset before setting a resource token"})
 
     def test_missing_url_template_config_causes_blocked_state(self):
         """A test for missing url template."""


### PR DESCRIPTION
> paired with @babakks on this.

Add sync token to config.

If you try to set the resource the token with sync-token an error will be returned.
If sync token is not present in an airgapped environment we disable the sync to avoid errors afterwards.