### PR TITLE
Improve multi-unit function

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -242,7 +242,7 @@ class LivepatchCharm(CharmBase):
 
         return env_vars
 
-    def _update_workload_container_config(self, event: HookEvent | None):
+    def _update_workload_container_config(self, event: Optional[HookEvent]):
         """
         Update workload with all available configuration data.
 
@@ -715,7 +715,7 @@ class LivepatchCharm(CharmBase):
 {"}"}
 """
 
-    def _push_to_workload(self, filename, content, event: HookEvent | None):
+    def _push_to_workload(self, filename, content, event: Optional[HookEvent]):
         """
         Create file on the workload container with the specified content.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -676,6 +676,20 @@ class LivepatchCharm(CharmBase):
             )
             return
 
+        # If there already is an integration with the `pro-airgapped-server`
+        # the user shouldn't be able to run this action, unless they remove the
+        # relation.
+        if self._get_available_pro_airgapped_server_address():
+            LOGGER.error(
+                "already integrated with `pro-airgapped-server`. The relation should be removed before setting a resource token"
+            )
+            event.set_results(
+                {
+                    "error": "already integrated with `pro-airgapped-server`. The relation should be removed before setting a resource token"
+                }
+            )
+            return
+
         contract_token = event.params.get("contract-token", "")
         if not contract_token:
             event.set_results({"error": "cannot fetch the resource token: no contract token provided"})

--- a/src/charm.py
+++ b/src/charm.py
@@ -746,7 +746,7 @@ class LivepatchCharm(CharmBase):
             container (Container): The workload container, the caller must ensure that we can connect.
         """
         if not self.config.get("contracts.ca"):
-            LOGGER.info("ca config not set")
+            LOGGER.debug("ca config not set")
             return
 
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -182,7 +182,7 @@ class LivepatchCharm(CharmBase):
                 container.stop(LIVEPATCH_SERVICE_NAME)
         self.unit.status = WaitingStatus("service stopped")
 
-    def handle_schema_upgrade(self, event):
+    def handle_schema_upgrade(self):
         """Check if a schema upgrade is required, and perform it."""
         dsn = self._state.dsn
         if not dsn:
@@ -269,7 +269,7 @@ class LivepatchCharm(CharmBase):
         self._push_to_workload(LOGROTATE_CONFIG_PATH, self._get_logrotate_config(), event)
 
         try:
-            self.handle_schema_upgrade(event)
+            self.handle_schema_upgrade()
         except DeferError:
             if event:
                 event.defer()

--- a/src/charm.py
+++ b/src/charm.py
@@ -760,7 +760,7 @@ class LivepatchCharm(CharmBase):
         LOGGER.info("stdout update-ca-certificates: %s", stdout)
         LOGGER.info("stderr update-ca-certificates: %s", stderr)
 
-    def _defer(self, event: HookEvent | None):
+    def _defer(self, event: Optional[HookEvent]):
         """
         Defer given event object if it's not None.
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -437,7 +437,7 @@ class TestCharm(unittest.TestCase):
         self.harness.enable_hooks()
 
         self.start_container()
-
+        del self.harness.charm._state.resource_token
         contracts_url = self.harness.charm.config.get("contracts.url")
 
         def make_request_side_effect(method: str, url: str, *args, **kwargs):
@@ -462,6 +462,7 @@ class TestCharm(unittest.TestCase):
         self.harness.enable_hooks()
 
         self.start_container()
+        del self.harness.charm._state.resource_token
 
         output = self.harness.run_action("get-resource-token", {"contract-token": "some-token"})
 
@@ -473,6 +474,7 @@ class TestCharm(unittest.TestCase):
         self.harness.enable_hooks()
 
         self.start_container()
+        del self.harness.charm._state.resource_token
 
         output = self.harness.run_action("get-resource-token", {"contract-token": ""})
 
@@ -484,6 +486,7 @@ class TestCharm(unittest.TestCase):
         self.harness.enable_hooks()
 
         self.start_container()
+        del self.harness.charm._state.resource_token
         self.harness.update_config({"patch-sync.token": "AAAABBBB"})
 
         output = self.harness.run_action("get-resource-token", {"contract-token": "some-token"})


### PR DESCRIPTION
This PR improves the charm regarding multi-unit deployments. Before this, the non-leader unit didn't subscribe to the peer `relation-changed` hook. This prevented non-leader units from updating the workload and accommodating the latest changes.

Also, there was a bug where running the `get-resource-token` action wouldn't erase the blocking status.

Fixes CSS-11329