### PR TITLE
Add integration with CVE service charm

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -95,6 +95,7 @@ jobs:
           channel: 6.1/stable
       - name: Bootstrap a controller on the LXD cloud
         run: |
+          newgrp lxd
           juju bootstrap localhost localhost-localhost
       # We need to change the MicroK8s API address from a localhost (127.0.0.1)
       # to a concrete IP address that is accessible by LXD containers/instances,

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Charmcraft
         run: sudo snap install charmcraft --classic
       - name: Build charm
-        run: charmcraft pack --platform ubuntu-20.04-amd64_ubuntu-22.04-amd64 --destructive-mode --verbosity=trace
+        run: charmcraft pack --platform ubuntu-20.04-amd64_ubuntu-24.04-amd64 --destructive-mode --verbosity=trace
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
@@ -61,7 +61,7 @@ jobs:
       - name: Install Charmcraft
         run: sudo snap install charmcraft --classic
       - name: Build charm
-        run: charmcraft pack --platform ubuntu-20.04-amd64_ubuntu-22.04-amd64 --destructive-mode --verbosity=trace
+        run: charmcraft pack --platform ubuntu-20.04-amd64_ubuntu-24.04-amd64 --destructive-mode --verbosity=trace
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -89,13 +89,8 @@ jobs:
       # MicroK8s cloud to the LXD controller, so that Livepatch and
       # `pro-airgapped-server` models share the same controller and therefore
       # can be integrated with each other over a cross-model relation.
-      - name: Install LXD
-        uses: canonical/setup-lxd@v0.1.1
-        with:
-          channel: 6.1/stable
       - name: Bootstrap a controller on the LXD cloud
         run: |
-          newgrp lxd
           juju bootstrap localhost localhost-localhost
       # We need to change the MicroK8s API address from a localhost (127.0.0.1)
       # to a concrete IP address that is accessible by LXD containers/instances,

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Charmcraft
         run: sudo snap install charmcraft --classic
       - name: Build charm
-        run: charmcraft pack --platform ubuntu-20.04-amd64_ubuntu-24.04-amd64 --destructive-mode --verbosity=trace
+        run: charmcraft pack --platform amd64 --destructive-mode --verbosity=trace
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
@@ -61,7 +61,7 @@ jobs:
       - name: Install Charmcraft
         run: sudo snap install charmcraft --classic
       - name: Build charm
-        run: charmcraft pack --platform ubuntu-20.04-amd64_ubuntu-24.04-amd64 --destructive-mode --verbosity=trace
+        run: charmcraft pack --platform amd64 --destructive-mode --verbosity=trace
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -5,6 +5,9 @@ header:
       content: |
         Copyright [year] [owner]
         See LICENSE file for licensing details.
+      pattern: |
+        Copyright \d{4} Canonical Ltd.
+        See LICENSE file for licensing details.
     paths:
       - '**'
     paths-ignore:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,15 +1,5 @@
 header:
   - license:
-      copyright-owner: Canonical Ltd.
-      content: |
-        Copyright [year] [owner]
-        Licensed under the Apache2.0. See LICENSE file in charm source for details.
-    paths:
-      - 'lib/**'
-    paths-ignore:
-      - 'lib/charms/grafana_k8s/v0/**'
-    comment: on-failure
-  - license:
       spdx-id: Apache-2.0
       copyright-owner: Canonical Ltd.
       content: |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Livepatch can be optionally integrated with [`pro-airgapped-server`](https://cha
 juju integrate canonical-livepatch-server:pro-airgapped-server pro-airgapped-server
 ```
 
+### Livepatch CVE service (optional, requires)
+
+Livepatch can be optionally integrated with [Livepatch CVE service](https://charmhub.io/canonical-livepatch-cve-k8s) via the `cve-catalog` endpoint. This integration provides the Livepatch server with the information about CVEs fixed in Ubuntu kernels. The integration can be done by using this command:
+
+```sh
+juju integrate canonical-livepatch-server canonical-livepatch-cve-k8s
+```
+
 ## OCI Image
 
 This charm uses an OCI image, built as a ROCK and published on GitHub Container Registry (GHCR) as `ghcr.io/canonical/livepatch-server`.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,7 +8,7 @@ type: "charm"
 bases:
   - build-on:
     - name: "ubuntu"
-      channel: "22.04"
+      channel: "24.04"
       architectures:
       - amd64
     run-on:
@@ -18,6 +18,10 @@ bases:
       - amd64
     - name: "ubuntu"
       channel: "22.04"
+      architectures:
+      - amd64
+    - name: "ubuntu"
+      channel: "24.04"
       architectures:
       - amd64
 parts:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,25 +5,11 @@
 # https://juju.is/docs/sdk/charmcraft-config
 type: "charm"
 # Note that ops 2.0 requires Python 3.8+ which is only shipped on Ubuntu 20.04 and above.
-bases:
-  - build-on:
-    - name: "ubuntu"
-      channel: "24.04"
-      architectures:
-      - amd64
-    run-on:
-    - name: "ubuntu"
-      channel: "20.04"
-      architectures:
-      - amd64
-    - name: "ubuntu"
-      channel: "22.04"
-      architectures:
-      - amd64
-    - name: "ubuntu"
-      channel: "24.04"
-      architectures:
-      - amd64
+
+base: ubuntu@24.04
+platforms:
+  amd64:
+
 parts:
   charm:
     build-packages: [git]

--- a/config.yaml
+++ b/config.yaml
@@ -295,6 +295,42 @@ options:
     description: How often to check for new blocklist entries.
     type: string
 
+  cve-lookup.enabled:
+    default: false
+    description: |
+      Whether or not if this instance of Livepatch Server should lookup fixed CVEs in response to client requests.
+    type: boolean
+  cve-sync.enabled:
+    default: false
+    description: |
+      Whether or not if this instance of Livepatch Server should sync fixec CVEs data.
+    type: boolean
+  cve-sync.source_url:
+    default: ""
+    description: |
+      Address of Livepatch CVE service to sync fixed CVEs data from.
+    type: string
+  cve-sync.interval:
+    default: "1h"
+    description: Period between automatic refreshing of fixed CVE data.
+    type: string
+  cve-sync.proxy.enabled:
+    default: false
+    description: Whether or not to proxy fixed CVE data syncs.
+    type: boolean
+  cve-sync.proxy.http:
+    default: ""
+    description: A comma separated list HTTP proxies to query fixed CVE data.
+    type: string
+  cve-sync.proxy.https:
+    default: ""
+    description: A comma separated list HTTPS proxies to query fixed CVE data.
+    type: string
+  cve-sync.proxy.no-proxy:
+    default: ""
+    description: A comma separated list of domains, IP CIDRs and/or ports to block when querying fixed CVE data.
+    type: string
+
   machine-reports.database.enabled:
     default: false
     description: Whether or not to enabled machine reports writes to PostgreSQL.

--- a/config.yaml
+++ b/config.yaml
@@ -300,6 +300,11 @@ options:
     description: |
       Whether or not if this instance of Livepatch Server should lookup fixed CVEs in response to client requests.
     type: boolean
+  cve-lookup.auth-required:
+    default: false
+    description: |
+      Whether or not requests to retrieve fixed CVEs should be authenticated.
+    type: boolean
   cve-sync.enabled:
     default: false
     description: |

--- a/config.yaml
+++ b/config.yaml
@@ -308,7 +308,7 @@ options:
   cve-sync.enabled:
     default: false
     description: |
-      Whether or not if this instance of Livepatch Server should sync fixec CVEs data.
+      Whether or not if this instance of Livepatch Server should sync fixed CVEs data.
     type: boolean
   cve-sync.source_url:
     default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -310,7 +310,7 @@ options:
     description: |
       Whether or not if this instance of Livepatch Server should sync fixed CVEs data.
     type: boolean
-  cve-sync.source_url:
+  cve-sync.source-url:
     default: ""
     description: |
       Address of Livepatch CVE service to sync fixed CVEs data from.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -73,11 +73,11 @@ resources:
   livepatch-server-image:
     type: oci-image
     description: OCI Image for Livepatch Server
-    upstream-source: ghcr.io/canonical/livepatch-server:v1.16.0
+    upstream-source: ghcr.io/canonical/livepatch-server:v1.17.0
   livepatch-schema-upgrade-tool-image:
     type: oci-image
     description: OCI Image for Schema upgrade tool
-    upstream-source: ghcr.io/canonical/livepatch-server:v1.16.0
+    upstream-source: ghcr.io/canonical/livepatch-server:v1.17.0
   # Temporary workaround until pebble can forward logs to Loki directly.
   promtail-bin:
     type: file

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -46,6 +46,10 @@ requires:
   database:
     interface: postgresql_client
     limit: 1 # Most charms only handle a single PostgreSQL Application.
+  cve-catalog:
+    interface: cve-catalog
+    limit: 1
+    optional: true
   pro-airgapped-server:
     interface: livepatch-pro-airgapped-server
     limit: 1

--- a/src/charm.py
+++ b/src/charm.py
@@ -100,12 +100,8 @@ class LivepatchCharm(CharmBase):
         )
 
         # Livepatch CVE service
-        self.framework.observe(
-            self.on.cve_catalog_relation_changed, self._on_cve_catalog_relation_changed
-        )
-        self.framework.observe(
-            self.on.cve_catalog_relation_broken, self._on_cve_catalog_relation_broken
-        )
+        self.framework.observe(self.on.cve_catalog_relation_changed, self._on_cve_catalog_relation_changed)
+        self.framework.observe(self.on.cve_catalog_relation_broken, self._on_cve_catalog_relation_broken)
 
         # Ingress (nginx-routes interface)
         require_nginx_route(

--- a/src/charm.py
+++ b/src/charm.py
@@ -233,12 +233,10 @@ class LivepatchCharm(CharmBase):
                 env_vars["LP_PATCH_SYNC_ID"] = self.model.uuid
 
         cve_service_address = self._get_available_cve_service()
-        if cve_service_address:
-            env_vars["LP_CVE_LOOKUP_ENABLED"] = True
-            if self.unit.is_leader():
-                # Note that other env vars are already set from the configuration.
-                env_vars["LP_CVE_SYNC_ENABLED"] = True
-                env_vars["LP_CVE_SYNC_SOURCE_URL"] = cve_service_address
+        if cve_service_address and self.unit.is_leader():
+            # Note that other env vars are already set from the configuration.
+            env_vars["LP_CVE_SYNC_ENABLED"] = True
+            env_vars["LP_CVE_SYNC_SOURCE_URL"] = cve_service_address
 
         # Some extra config and checks
         env_vars["LP_DATABASE_CONNECTION_STRING"] = self._state.dsn

--- a/src/charm.py
+++ b/src/charm.py
@@ -33,6 +33,7 @@ LIVEPATCH_SERVICE_NAME = "livepatch"
 DATABASE_RELATION = "database"
 DATABASE_RELATION_LEGACY = "database-legacy"
 PRO_AIRGAPPED_SERVER_RELATION = "pro-airgapped-server"
+CVE_CATALOG_RELATION = "cve-catalog"
 
 REQUIRED_SETTINGS = {
     "server.url-template": "✘ server.url-template config not set",
@@ -96,6 +97,14 @@ class LivepatchCharm(CharmBase):
         )
         self.framework.observe(
             self.on.pro_airgapped_server_relation_departed, self._on_pro_airgapped_server_relation_departed
+        )
+
+        # Livepatch CVE service
+        self.framework.observe(
+            self.on.cve_catalog_relation_changed, self._on_cve_catalog_relation_changed
+        )
+        self.framework.observe(
+            self.on.cve_catalog_relation_broken, self._on_cve_catalog_relation_broken
         )
 
         # Ingress (nginx-routes interface)
@@ -227,6 +236,14 @@ class LivepatchCharm(CharmBase):
                 # TODO: Find a better way to identify a on-prem syncing instance.
                 env_vars["LP_PATCH_SYNC_ID"] = self.model.uuid
 
+        cve_service_address = self._get_available_cve_service()
+        if cve_service_address:
+            env_vars["LP_CVE_LOOKUP_ENABLED"] = True
+            if self.unit.is_leader():
+                # Note that other env vars are already set from the configuration.
+                env_vars["LP_CVE_SYNC_ENABLED"] = True
+                env_vars["LP_CVE_SYNC_SOURCE_URL"] = cve_service_address
+
         # Some extra config and checks
         env_vars["LP_DATABASE_CONNECTION_STRING"] = self._state.dsn
         env_vars["LP_SERVER_SERVER_ADDRESS"] = f":{SERVER_PORT}"
@@ -238,7 +255,7 @@ class LivepatchCharm(CharmBase):
             env_vars["LP_PATCH_STORAGE_POSTGRES_CONNECTION_STRING"] = postgres_patch_storage_dsn
 
         # remove empty environment values
-        env_vars = {key: value for key, value in env_vars.items() if value}
+        env_vars = {key: value for key, value in env_vars.items() if (not isinstance(value, str) or value)}
 
         return env_vars
 
@@ -510,6 +527,23 @@ class LivepatchCharm(CharmBase):
         port = data.get("port")
         netloc = hostname + (f":{port}" if port else "")
         return urlunparse(ParseResult(scheme, netloc, "", "", "", ""))
+
+    def _on_cve_catalog_relation_changed(self, event: RelationChangedEvent):
+        """Handle cve-catalog relation-changed event."""
+        self._update_workload_container_config(event)
+
+    def _on_cve_catalog_relation_broken(self, event: RelationDepartedEvent):
+        """Handle cve-catalog relation-broken event."""
+        self._update_workload_container_config(event)
+
+    def _get_available_cve_service(self) -> Optional[str]:
+        """Return the Livepatch CVE service address, if any, taken from related app/unit."""
+        relation = self.model.get_relation(CVE_CATALOG_RELATION)
+        if not relation:
+            return None
+
+        address = relation.data.get(relation.app).get("url", "")
+        return address if address else None
 
     # Actions
     def restart_action(self, event):

--- a/src/charm.py
+++ b/src/charm.py
@@ -249,7 +249,7 @@ class LivepatchCharm(CharmBase):
             env_vars["LP_PATCH_STORAGE_POSTGRES_CONNECTION_STRING"] = postgres_patch_storage_dsn
 
         # remove empty environment values
-        env_vars = {key: value for key, value in env_vars.items() if (not isinstance(value, str) or value)}
+        env_vars = {key: value for key, value in env_vars.items() if value != ""}
 
         return env_vars
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,7 +4,7 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import unittest
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 from unittest.mock import Mock, patch
 
 import yaml

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1292,7 +1292,7 @@ class TestCharm(unittest.TestCase):
 
         self._assert_environment_contains(
             {
-                "LP_CVE_LOOKUP_ENABLED": True,
+                "LP_CVE_LOOKUP_ENABLED": False,  # Should not get enabled automatically.
                 "LP_CVE_SYNC_ENABLED": True,
                 "LP_CVE_SYNC_SOURCE_URL": "scheme://some.host.name:9999",
                 "LP_CVE_SYNC_INTERVAL": "1h",  # Default config value.
@@ -1328,7 +1328,7 @@ class TestCharm(unittest.TestCase):
 
             self._assert_environment_contains(
                 {
-                    "LP_CVE_LOOKUP_ENABLED": True,
+                    "LP_CVE_LOOKUP_ENABLED": False,  # Should not get enabled automatically.
                     "LP_CVE_SYNC_ENABLED": True,
                     "LP_CVE_SYNC_SOURCE_URL": "scheme://some.host.name:9999",
                     "LP_CVE_SYNC_INTERVAL": "1h",  # Default config value.


### PR DESCRIPTION
This PR adds integration with the CVE service charm.

The PR should not be merged until we have released the server OCI images that support the corresponding functionalities.

Fixes CSS-12872