### PR TITLE
Add integration with the new CVE service charm

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -69,7 +69,7 @@ jobs:
           channel: 1.30-strict/stable
           juju-channel: 2.9/stable
           provider: microk8s
-          microk8s-group: snap_microk8s
+          microk8s-group: runner
           microk8s-addons: "ingress storage dns rbac registry"
       # Instructions from https://microk8s.io/docs/registry-private
       # and https://github.com/containerd/cri/blob/master/docs/registry.md
@@ -83,12 +83,6 @@ jobs:
           EOL
           echo "$REGISTRY_CONFIG" | sudo tee -a /var/snap/microk8s/current/args/containerd-template.toml
           sudo snap restart microk8s.daemon-containerd
-
-      - name: Allow the runner to access microk8s
-        run: |
-          sudo usermod -a -G snap_microk8s runner
-          sudo chown -R runner ~/.kube
-          newgrp snap_microk8s
 
       # LXD is needed for testing the integration with `pro-airgapped-server`
       # because there's no K8s version of this charm. We also need to add the

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -69,7 +69,7 @@ jobs:
           channel: 1.30-strict/stable
           juju-channel: 2.9/stable
           provider: microk8s
-          microk8s-group: runner
+          microk8s-group: snap_microk8s
           microk8s-addons: "ingress storage dns rbac registry"
       # Instructions from https://microk8s.io/docs/registry-private
       # and https://github.com/containerd/cri/blob/master/docs/registry.md
@@ -83,6 +83,12 @@ jobs:
           EOL
           echo "$REGISTRY_CONFIG" | sudo tee -a /var/snap/microk8s/current/args/containerd-template.toml
           sudo snap restart microk8s.daemon-containerd
+
+      - name: Allow the runner to access microk8s
+        run: |
+          sudo usermod -a -G snap_microk8s runner
+          sudo chown -R runner ~/.kube
+          sudo newgrp snap_microk8s
 
       # LXD is needed for testing the integration with `pro-airgapped-server`
       # because there's no K8s version of this charm. We also need to add the

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           channel: 1.30-strict/stable
-          juju-channel: 3.5/stable
+          juju-channel: 2.9/stable
           provider: microk8s
           microk8s-group: snap_microk8s
           microk8s-addons: "ingress storage dns rbac registry"
@@ -67,7 +67,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           channel: 1.30-strict/stable
-          juju-channel: 3.5/stable
+          juju-channel: 2.9/stable
           provider: microk8s
           microk8s-group: snap_microk8s
           microk8s-addons: "ingress storage dns rbac registry"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -90,7 +90,7 @@ jobs:
       # `pro-airgapped-server` models share the same controller and therefore
       # can be integrated with each other over a cross-model relation.
       - name: Bootstrap a controller on the LXD cloud
-        run: sudo juju bootstrap localhost localhost-localhost
+        run: /usr/bin/sudo -g snap_microk8s -E juju bootstrap localhost localhost-localhost
       # We need to change the MicroK8s API address from a localhost (127.0.0.1)
       # to a concrete IP address that is accessible by LXD containers/instances,
       # including the controller we have just bootstrapped. Note that the output

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -84,20 +84,13 @@ jobs:
           echo "$REGISTRY_CONFIG" | sudo tee -a /var/snap/microk8s/current/args/containerd-template.toml
           sudo snap restart microk8s.daemon-containerd
 
-      - name: Allow the runner to access microk8s
-        run: |
-          sudo usermod -a -G snap_microk8s runner
-          sudo chown -R runner ~/.kube
-          sudo newgrp snap_microk8s
-          sleep 5
-
       # LXD is needed for testing the integration with `pro-airgapped-server`
       # because there's no K8s version of this charm. We also need to add the
       # MicroK8s cloud to the LXD controller, so that Livepatch and
       # `pro-airgapped-server` models share the same controller and therefore
       # can be integrated with each other over a cross-model relation.
       - name: Bootstrap a controller on the LXD cloud
-        run: juju bootstrap localhost localhost-localhost
+        run: sudo juju bootstrap localhost localhost-localhost
       # We need to change the MicroK8s API address from a localhost (127.0.0.1)
       # to a concrete IP address that is accessible by LXD containers/instances,
       # including the controller we have just bootstrapped. Note that the output

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -89,6 +89,7 @@ jobs:
           sudo usermod -a -G snap_microk8s runner
           sudo chown -R runner ~/.kube
           sudo newgrp snap_microk8s
+          sleep 5
 
       # LXD is needed for testing the integration with `pro-airgapped-server`
       # because there's no K8s version of this charm. We also need to add the

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   integration-test:
     name: Integration tests (MicroK8s controller)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
         uses: canonical/charming-actions/dump-logs@main
   integration-test-airgapped:
     name: Airgapped integration tests (LXD controller)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -84,6 +84,11 @@ jobs:
           echo "$REGISTRY_CONFIG" | sudo tee -a /var/snap/microk8s/current/args/containerd-template.toml
           sudo snap restart microk8s.daemon-containerd
 
+      # LXD is needed for testing the integration with `pro-airgapped-server`
+      # because there's no K8s version of this charm. We also need to add the
+      # MicroK8s cloud to the LXD controller, so that Livepatch and
+      # `pro-airgapped-server` models share the same controller and therefore
+      # can be integrated with each other over a cross-model relation.
       - name: Bootstrap a controller on the LXD cloud
         run: juju bootstrap localhost localhost-localhost
       # We need to change the MicroK8s API address from a localhost (127.0.0.1)

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -84,6 +84,12 @@ jobs:
           echo "$REGISTRY_CONFIG" | sudo tee -a /var/snap/microk8s/current/args/containerd-template.toml
           sudo snap restart microk8s.daemon-containerd
 
+      - name: Allow the runner to access microk8s
+        run: |
+          sudo usermod -a -G snap_microk8s runner
+          sudo chown -R runner ~/.kube
+          newgrp snap_microk8s
+
       # LXD is needed for testing the integration with `pro-airgapped-server`
       # because there's no K8s version of this charm. We also need to add the
       # MicroK8s cloud to the LXD controller, so that Livepatch and

--- a/.github/workflows/promote_bundle.yaml
+++ b/.github/workflows/promote_bundle.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   promote-livepatch-operator-k8s-bundle:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish_bundle.yaml
+++ b/.github/workflows/publish_bundle.yaml
@@ -12,7 +12,7 @@ run-name: Release bundle by @${{ github.actor }}
 
 jobs:
   upload-livepatch-operator-k8s-bundle:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -12,7 +12,7 @@ run-name: Release charm by @${{ github.actor }}
 
 jobs:
   upload-livepatch-operator-k8s:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Livepatch can be optionally integrated with [`pro-airgapped-server`](https://cha
 juju integrate canonical-livepatch-server:pro-airgapped-server pro-airgapped-server
 ```
 
+### Livepatch CVE service (optional, requires)
+
+Livepatch can be optionally integrated with [Livepatch CVE service](https://charmhub.io/canonical-livepatch-cve-k8s) via the `cve-catalog` endpoint. This integration provides the Livepatch server with the information about CVEs fixed in Ubuntu kernels. The integration can be done by using this command:
+
+```sh
+juju integrate canonical-livepatch-server canonical-livepatch-cve-k8s
+```
+
 ## OCI Image
 
 This charm uses an OCI image, built as a ROCK and published on GitHub Container Registry (GHCR) as `ghcr.io/canonical/livepatch-server`.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,7 +4,7 @@
 # Learn more about charmcraft.yaml configuration at:
 # https://juju.is/docs/sdk/charmcraft-config
 type: "charm"
-base: ubuntu@24.04
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: [amd64]

--- a/config.yaml
+++ b/config.yaml
@@ -295,6 +295,47 @@ options:
     description: How often to check for new blocklist entries.
     type: string
 
+  cve-lookup.enabled:
+    default: false
+    description: |
+      Whether or not if this instance of Livepatch Server should lookup fixed CVEs in response to client requests.
+    type: boolean
+  cve-lookup.auth-required:
+    default: false
+    description: |
+      Whether or not requests to retrieve fixed CVEs should be authenticated.
+    type: boolean
+  cve-sync.enabled:
+    default: false
+    description: |
+      Whether or not if this instance of Livepatch Server should sync fixed CVEs data.
+    type: boolean
+  cve-sync.source-url:
+    default: ""
+    description: |
+      Address of Livepatch CVE service to sync fixed CVEs data from.
+    type: string
+  cve-sync.interval:
+    default: "1h"
+    description: Period between automatic refreshing of fixed CVE data.
+    type: string
+  cve-sync.proxy.enabled:
+    default: false
+    description: Whether or not to proxy fixed CVE data syncs.
+    type: boolean
+  cve-sync.proxy.http:
+    default: ""
+    description: A comma separated list HTTP proxies to query fixed CVE data.
+    type: string
+  cve-sync.proxy.https:
+    default: ""
+    description: A comma separated list HTTPS proxies to query fixed CVE data.
+    type: string
+  cve-sync.proxy.no-proxy:
+    default: ""
+    description: A comma separated list of domains, IP CIDRs and/or ports to block when querying fixed CVE data.
+    type: string
+
   machine-reports.database.enabled:
     default: false
     description: Whether or not to enabled machine reports writes to PostgreSQL.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -46,6 +46,10 @@ requires:
   database:
     interface: postgresql_client
     limit: 1 # Most charms only handle a single PostgreSQL Application.
+  cve-catalog:
+    interface: cve-catalog
+    limit: 1
+    optional: true
   pro-airgapped-server:
     interface: livepatch-pro-airgapped-server
     limit: 1

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -118,8 +118,8 @@ async def perform_livepatch_integrations(ops_test: OpsTest):
         ops_test: PyTest object.
     """
     logger.info("Integrating Livepatch and Postgresql")
-    await ops_test.model.integrate(f"{APP_NAME}:database", f"{POSTGRESQL_NAME}:database")
-    await ops_test.model.integrate(f"{APP_NAME}:nginx-route", f"{NGINX_INGRESS_CHARM_NAME}:nginx-route")
+    await ops_test.model.relate(f"{APP_NAME}:database", f"{POSTGRESQL_NAME}:database")
+    await ops_test.model.relate(f"{APP_NAME}:nginx-route", f"{NGINX_INGRESS_CHARM_NAME}:nginx-route")
 
 
 def get_charm_resources():

--- a/tests/integration/test_airgapped.py
+++ b/tests/integration/test_airgapped.py
@@ -111,7 +111,7 @@ async def test_airgapped_contracts_integration(ops_test: OpsTest):
                 apps=[PRO_AIRGAPPED_SERVER_NAME], status=ACTIVE_STATUS, raise_on_blocked=False, timeout=600
             )
 
-            offer_name = "pro-airgapped-server-offer"
+            offer_name = f"{PRO_AIRGAPPED_SERVER_NAME}:{PRO_AIRGAPPED_SERVER_ENDPOINT}"
             logger.info("Creating application offer for cross-model relation: %s", offer_name)
             await ops_test.model.create_offer(
                 endpoint=PRO_AIRGAPPED_SERVER_ENDPOINT,

--- a/tests/integration/test_airgapped.py
+++ b/tests/integration/test_airgapped.py
@@ -111,10 +111,10 @@ async def test_airgapped_contracts_integration(ops_test: OpsTest):
                 apps=[PRO_AIRGAPPED_SERVER_NAME], status=ACTIVE_STATUS, raise_on_blocked=False, timeout=600
             )
 
-            offer_name = f"{PRO_AIRGAPPED_SERVER_NAME}:{PRO_AIRGAPPED_SERVER_ENDPOINT}"
+            offer_name = "pro-airgapped-server-offer"
             logger.info("Creating application offer for cross-model relation: %s", offer_name)
             await ops_test.model.create_offer(
-                endpoint=PRO_AIRGAPPED_SERVER_ENDPOINT,
+                endpoint=f"{PRO_AIRGAPPED_SERVER_NAME}:{PRO_AIRGAPPED_SERVER_ENDPOINT}",
                 application_name=PRO_AIRGAPPED_SERVER_NAME,
                 offer_name=offer_name,
             )

--- a/tests/integration/test_airgapped.py
+++ b/tests/integration/test_airgapped.py
@@ -136,7 +136,7 @@ async def test_airgapped_contracts_integration(ops_test: OpsTest):
             # handles this by defaulting to the current user.
             await ops_test.juju("consume", f"{lxd_model_name}.{offer_name}")
             logger.info("Integrating Livepatch and pro-airgapped-server")
-            await ops_test.model.integrate(APP_NAME, offer_name)
+            await ops_test.model.relate(APP_NAME, offer_name)
             logger.info("Waiting for Livepatch")
             await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,7 +4,7 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import unittest
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 from unittest.mock import Mock, patch
 
 import yaml
@@ -1092,8 +1092,8 @@ class TestCharm(unittest.TestCase):
             {
                 "LP_CONTRACTS_ENABLED": True,
                 "LP_CONTRACTS_URL": "scheme://some.host.name:9999",
+                "LP_PATCH_SYNC_ENABLED": False,
             },
-            {"LP_PATCH_SYNC_ENABLED": True},
         )
 
     def test_pro_airgapped_server_relation__multiple_units(self):
@@ -1263,7 +1263,89 @@ class TestCharm(unittest.TestCase):
                 }
             )
 
-    def _assert_environment_contains(self, contains: Dict[str, Any], not_contains: Union[List[str], None] = None):
+    def test_cve_catalog_relation__success(self):
+        """Test cve-catalog relation."""
+        self.harness.set_leader(True)
+        self.harness.enable_hooks()
+
+        self.harness.charm._state.dsn = "postgresql://123"
+        self.harness.charm._state.resource_token = TEST_TOKEN
+
+        with patch("src.charm.LivepatchCharm.migration_is_required") as migration:
+            migration.return_value = False
+            self.harness.update_config(
+                {
+                    "server.url-template": "http://localhost/{filename}",
+                    "server.is-hosted": False,
+                }
+            )
+
+            cves_rel_id = self.harness.add_relation("cve-catalog", "livepatch-cve-service")
+            self.harness.add_relation_unit(cves_rel_id, "livepatch-cve-service/0")
+            self.harness.update_relation_data(
+                cves_rel_id,
+                "livepatch-cve-service",
+                {
+                    "url": "scheme://some.host.name:9999",
+                },
+            )
+
+        self._assert_environment_contains(
+            {
+                "LP_CVE_LOOKUP_ENABLED": False,  # Should not get enabled automatically.
+                "LP_CVE_SYNC_ENABLED": True,
+                "LP_CVE_SYNC_SOURCE_URL": "scheme://some.host.name:9999",
+                "LP_CVE_SYNC_INTERVAL": "1h",  # Default config value.
+            }
+        )
+
+    def test_cve_catalog_relation__relation_removed(self):
+        """Test when cve-catalog is removed."""
+        self.harness.set_leader(True)
+        self.harness.enable_hooks()
+
+        self.harness.charm._state.dsn = "postgresql://123"
+        self.harness.charm._state.resource_token = TEST_TOKEN
+
+        with patch("src.charm.LivepatchCharm.migration_is_required") as migration:
+            migration.return_value = False
+            self.harness.update_config(
+                {
+                    "server.url-template": "http://localhost/{filename}",
+                    "server.is-hosted": False,
+                }
+            )
+
+            cves_rel_id = self.harness.add_relation("cve-catalog", "livepatch-cve-service")
+            self.harness.add_relation_unit(cves_rel_id, "livepatch-cve-service/0")
+            self.harness.update_relation_data(
+                cves_rel_id,
+                "livepatch-cve-service",
+                {
+                    "url": "scheme://some.host.name:9999",
+                },
+            )
+
+            self._assert_environment_contains(
+                {
+                    "LP_CVE_LOOKUP_ENABLED": False,  # Should not get enabled automatically.
+                    "LP_CVE_SYNC_ENABLED": True,
+                    "LP_CVE_SYNC_SOURCE_URL": "scheme://some.host.name:9999",
+                    "LP_CVE_SYNC_INTERVAL": "1h",  # Default config value.
+                }
+            )
+
+            # Now we remove the relation.
+            self.harness.remove_relation(cves_rel_id)
+
+            self._assert_environment_contains(
+                {
+                    "LP_CVE_LOOKUP_ENABLED": False,
+                    "LP_CVE_SYNC_ENABLED": False,
+                },
+            )
+
+    def _assert_environment_contains(self, contains: Dict[str, Any]):
         """Assert Pebble plan environment contains given key/value pairs."""
         plan = self.harness.get_container_pebble_plan("livepatch")
         environment = plan.to_dict()["services"]["livepatch"]["environment"]

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ deps =
     pytest
     coverage[toml]
     jinja2
-    juju
+    juju~=2.9
     pytest
     pytest_asyncio
     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -100,7 +100,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju~=3.5
+    juju~=2.9
     pytest-operator~=0.37.0
     pytest-asyncio
     requests
@@ -112,7 +112,7 @@ commands =
 description = Run airgapped integration tests
 deps =
     pytest
-    juju~=3.5
+    juju~=2.9
     pytest-operator~=0.37.0
     pytest-asyncio
     requests


### PR DESCRIPTION
Adds changes from https://github.com/canonical/livepatch-k8s-operator/pull/45 with a few required fixes to make tests pass and use Juju 2.9 matching the destination environment. 