### PR TITLE
Release version 1.17.2

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -73,11 +73,11 @@ resources:
   livepatch-server-image:
     type: oci-image
     description: OCI Image for Livepatch Server
-    upstream-source: ghcr.io/canonical/livepatch-server:v1.17.1
+    upstream-source: ghcr.io/canonical/livepatch-server:v1.17.2
   livepatch-schema-upgrade-tool-image:
     type: oci-image
     description: OCI Image for Schema upgrade tool
-    upstream-source: ghcr.io/canonical/livepatch-server:v1.17.1
+    upstream-source: ghcr.io/canonical/livepatch-server:v1.17.2
   # Temporary workaround until pebble can forward logs to Loki directly.
   promtail-bin:
     type: file


### PR DESCRIPTION
## Description

Release version 1.17.2, forcing the updated OCI image to be used. 

Fixes *JIRA/GitHub issue number*

## Engineering checklist
*Check only items that apply*

- [ ] I have checked and added or updated relevant documentation.
- [ ] I have checked and added or updated relevant release notes.
- [ ] Covered by unit tests
- [ ] Covered by integration tests


## Notes for code reviewers

<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->
