### PR TITLE
Allow base channel selection in the charm promotion workflo

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -17,15 +17,26 @@ on:
             - latest/beta
             - latest/candidate
             - latest/stable
+        base-channel:
+            type: choice
+            description: 'Base Channel to promote'
+            options:
+            - "20.04"
+            - "22.04"
+            - "24.04"
+
     secrets:
         CHARMHUB_TOKEN:
             required: true
 
 jobs:
   promote:
-    name: Promote Charm
+    name: Promote Charm for base ${{ inputs.base-channel }}
     uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@main
     with:
-      origin-channel: ${{ github.event.inputs.origin-channel }}
-      destination-channel: ${{ github.event.inputs.destination-channel }}
+      origin-channel: ${{ inputs.origin-channel }}
+      destination-channel: ${{ inputs.destination-channel }}
+      base-channel: ${{ inputs.base-channel }}
+      base-name: ubuntu
+      base-architecture: amd64
     secrets: inherit


### PR DESCRIPTION
## Description

Fixes charm promotion by allowing the `base` to be selected. Successfully ran from the PRT branch: https://github.com/canonical/livepatch-k8s-operator/actions/runs/15654263947 . 

Fixes *JIRA/GitHub issue number*

## Engineering checklist
*Check only items that apply*

- [ ] I have checked and added or updated relevant documentation.
- [ ] I have checked and added or updated relevant release notes.
- [ ] Covered by unit tests
- [ ] Covered by integration tests


## Notes for code reviewers

<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->
