### PR TITLE
Expose OCI image version in charm

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -14,16 +14,6 @@ jobs:
   upload-livepatch-operator-k8s:
     runs-on: ubuntu-22.04
     steps:
-      - name: Update Server Version
-        run : |
-          bach -c '
-          echo "Updating version string...
-          yq -r 'to_entries[] | select(.key == "resources") | 
-          .value[] | .["upstream-source"]? ' metadata.yaml | 
-          head -n1 |  awk '{ match($0, /v[0-9]+(\.[0-9]+)*/, m); print m[0] }' 
-          > version 
-          echo "Updated version string to $(cat version)"
-          '
       - name: Checkout
         uses: actions/checkout@v4
       - name: Log in to the Container registry

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -14,6 +14,16 @@ jobs:
   upload-livepatch-operator-k8s:
     runs-on: ubuntu-22.04
     steps:
+      - name: Update Server Version
+        run : |
+          bach -c '
+          echo "Updating version string...
+          yq -r 'to_entries[] | select(.key == "resources") | 
+          .value[] | .["upstream-source"]? ' metadata.yaml | 
+          head -n1 |  awk '{ match($0, /v[0-9]+(\.[0-9]+)*/, m); print m[0] }' 
+          > version 
+          echo "Updated version string to $(cat version)"
+          '
       - name: Checkout
         uses: actions/checkout@v4
       - name: Log in to the Container registry

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,5 +21,4 @@ parts:
       - responses
     override-build: |
       craftctl default
-      yq -r 'to_entries[] | select(.key == "resources") | .value[] | .["upstream-source"]? ' metadata.yaml | head -n1 |  awk '{ match($0, /v[0-9]+(\.[0-9]+)*/, m); print m[0] }' > $CRAFT_PART_INSTALL/version
-
+      yq -r 'to_entries[] | select(.key == "resources") | .value[] | .["upstream-source"]? ' metadata.yaml | awk '{ match($0, /v[0-9]+(\.[0-9]+)*/, m); print m[0] }' | head -n1

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,5 +21,5 @@ parts:
       - responses
     override-build: |
       craftctl default
-      yq -r 'to_entries[] | select(.key == "resources") | .value[] | .["upstream-source"]? ' metadata.yaml | head -n1 |  awk '{ match($0, /v[0-9]+(\.[0-9]+)*/, m); print m[0] }' > version
+      yq -r 'to_entries[] | select(.key == "resources") | .value[] | .["upstream-source"]? ' metadata.yaml | head -n1 |  awk '{ match($0, /v[0-9]+(\.[0-9]+)*/, m); print m[0] }' > $CRAFT_PART_INSTALL/version
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,4 +21,4 @@ parts:
       - responses
     override-build: |
       craftctl default
-      yq -r 'to_entries[] | select(.key == "resources") | .value[] | .["upstream-source"]? ' metadata.yaml | awk '{ match($0, /v[0-9]+(\.[0-9]+)*/, m); print m[0] }' | head -n1
+      yq -r 'to_entries[] | select(.key == "resources") | .value[] | .["upstream-source"]? ' metadata.yaml | awk '{ match($0, /v[0-9]+(\.[0-9]+)*/, m); print m[0] }' | head -n1 > $CRAFT_PART_INSTALL/version

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -19,3 +19,7 @@ parts:
       - ops-lib-pgsql
       - requests
       - responses
+    override-build: |
+      craftctl default
+      yq -r 'to_entries[] | select(.key == "resources") | .value[] | .["upstream-source"]? ' metadata.yaml | head -n1 |  awk '{ match($0, /v[0-9]+(\.[0-9]+)*/, m); print m[0] }' > version
+

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -73,11 +73,11 @@ resources:
   livepatch-server-image:
     type: oci-image
     description: OCI Image for Livepatch Server
-    upstream-source: ghcr.io/canonical/livepatch-server:v1.17.4
+    upstream-source: ghcr.io/canonical/livepatch-server:v1.17.5
   livepatch-schema-upgrade-tool-image:
     type: oci-image
     description: OCI Image for Schema upgrade tool
-    upstream-source: ghcr.io/canonical/livepatch-server:v1.17.4
+    upstream-source: ghcr.io/canonical/livepatch-server:v1.17.5
   # Temporary workaround until pebble can forward logs to Loki directly.
   promtail-bin:
     type: file

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -138,11 +138,10 @@ def oci_image(metadata_file: str, image_name: str) -> str:
 
     return upstream_source
 
-def extract_version_from_metadata(path = '../../metadata.yaml'):
+def extract_version_from_metadata(path = 'metadata.yaml'):
     """extract the version string from the metadata.yaml file."""
     with open(path) as f:
         metadata = yaml.safe_load(f)
-
     resources = metadata.get("resources", {})
     for res in resources.values():
         upstream = res.get("upstream-source")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -2,11 +2,12 @@
 # See LICENSE file for licensing details.
 
 import logging
+import yaml
+import re
 import uuid
 from pathlib import Path
 from typing import Literal, Union
 
-import yaml
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from pytest_operator.plugin import OpsTest
 
@@ -136,3 +137,17 @@ def oci_image(metadata_file: str, image_name: str) -> str:
         raise ValueError("Upstream source not found")
 
     return upstream_source
+
+def extract_version_from_metadata(path = '../../metadata.yaml'):
+    """extract the version string from the metadata.yaml file."""
+    with open(path) as f:
+        metadata = yaml.safe_load(f)
+
+    resources = metadata.get("resources", {})
+    for res in resources.values():
+        upstream = res.get("upstream-source")
+        if upstream:
+            match = re.search(r"v[0-9]+(\.[0-9]+)*", upstream)
+            if match:
+                return match.group(0)
+    raise ValueError("No version found in upstream-source fields")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 import requests
 from fixtures import deploy_package
-from helpers import ACTIVE_STATUS, APP_NAME
+from helpers import ACTIVE_STATUS, APP_NAME, extract_version_from_metadata
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -30,3 +30,12 @@ async def test_application_is_up(ops_test: OpsTest):
     r = requests.get(url, timeout=2.0)
     assert r.status_code == 200
     logger.info(f"Output = {r.json()}")
+
+
+@pytest.mark.abort_on_fail
+async def test_charm_version_is_set(ops_test: OpsTest):
+    """Test correct version is set"""
+    status = await ops_test.model.get_status()
+    version = status.applications[APP_NAME].charm_version
+    expected_version = extract_version_from_metadata()
+    assert version == expected_version

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -41,4 +41,4 @@ async def test_charm_version_is_set(ops_test: OpsTest):
     craft_part_install = os.environ.get("CRAFT_PART_INSTALL")
     metadata_path = os.path.join(craft_part_install, "metadata.yaml")
     expected_version = extract_version_from_metadata(metadata_path)
-    assert version == expected_version
+    assert version == expected_version, f"expected {expected_version}, got {version}"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -38,6 +38,6 @@ async def test_charm_version_is_set(ops_test: OpsTest):
     """Test correct version is set"""
     status = await ops_test.model.get_status()
     version = status.applications[APP_NAME].charm_version
-    metadata_path = "../../metadata.yaml"
+    metadata_path = "metadata.yaml"
     expected_version = extract_version_from_metadata(metadata_path)
     assert version == expected_version, f"expected {expected_version}, got {version}"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 import logging
+import os
 
 import pytest
 import requests
@@ -37,5 +38,7 @@ async def test_charm_version_is_set(ops_test: OpsTest):
     """Test correct version is set"""
     status = await ops_test.model.get_status()
     version = status.applications[APP_NAME].charm_version
-    expected_version = extract_version_from_metadata()
+    craft_part_install = os.environ.get("CRAFT_PART_INSTALL")
+    metadata_path = os.path.join(craft_part_install, "metadata.yaml")
+    expected_version = extract_version_from_metadata(metadata_path)
     assert version == expected_version

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -38,7 +38,6 @@ async def test_charm_version_is_set(ops_test: OpsTest):
     """Test correct version is set"""
     status = await ops_test.model.get_status()
     version = status.applications[APP_NAME].charm_version
-    craft_part_install = os.environ.get("CRAFT_PART_INSTALL")
-    metadata_path = os.path.join(craft_part_install, "metadata.yaml")
+    metadata_path = "../../metadata.yaml"
     expected_version = extract_version_from_metadata(metadata_path)
     assert version == expected_version, f"expected {expected_version}, got {version}"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import os
 
 import pytest
 import requests


### PR DESCRIPTION
## Description
This PR adds the ability to see the OCI image version in the charm. When running Juju status, the server charm will show the current server version (i.e. 1.17.5).

## Notes for code reviewers
Charmcraft stores the version string by looking at a file called `version`. This file is created on the build step, and fetches the OCI image version from `metadata.yaml`.
