### PR TITLE
Expose version juju status

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -287,7 +287,6 @@ class LivepatchCharm(CharmBase):
         # Quickly update logrotates config each workload update
         self._push_to_workload(LOGROTATE_CONFIG_PATH, self._get_logrotate_config(), event)
 
-
         try:
             self.handle_schema_upgrade()
         except DeferError:

--- a/src/charm.py
+++ b/src/charm.py
@@ -253,8 +253,9 @@ class LivepatchCharm(CharmBase):
         env_vars = {key: value for key, value in env_vars.items() if value != "" and value is not None}
 
         return env_vars
+
     def _update_workload_version(self):
-        """Update the workload version. Version will be present in the Version column when running juju status"""
+        """Update the workload version. Version will be present in the Version column when running juju status."""
         charm_file = pathlib.Path("version")
         raw_version = charm_file.read_text(encoding="utf-8")
         version = raw_version.strip()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 import logging
+import pathlib
 
 import pytest
 import requests
@@ -37,6 +38,6 @@ async def test_charm_version_is_set(ops_test: OpsTest):
     """Test correct version is set"""
     status = await ops_test.model.get_status()
     version = status.applications[APP_NAME].charm_version
-    metadata_path = "metadata.yaml"
+    metadata_path = pathlib.Path("metadata.yaml")
     expected_version = extract_version_from_metadata(metadata_path)
     assert version == expected_version, f"expected {expected_version}, got {version}"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,11 +1,12 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
+import os
 import unittest
 from typing import Any, Dict, List
 from unittest.mock import Mock, patch
+import pathlib
 
 import yaml
 from ops import pebble
@@ -53,6 +54,11 @@ class TestCharm(unittest.TestCase):
     def setUp(self):
         self.harness = Harness(LivepatchCharm)
         self.addCleanup(self.harness.cleanup)
+
+        # create version file
+        self.version_file = pathlib.Path("version")
+        pathlib.Path.touch(self.version_file)
+        self.addCleanup( lambda: os.remove(self.version_file ) )
 
         self.harness.disable_hooks()
         self.harness.add_oci_resource("livepatch-server-image")


### PR DESCRIPTION
## Description
This PR addresses the OCI version displayed with juju status from #56. The version read from the `version` file is only present in json/yaml output when using the `--format` option with `juju status`. 

To show the version without needing to view json or yaml, we set the version string in the charm code by reading from the file and setting `unit.set_workload_version`



## Engineering checklist
*Check only items that apply*

- [ ] I have checked and added or updated relevant documentation.
- [ ] I have checked and added or updated relevant release notes.
- [ ] Covered by unit tests
- [ ] Covered by integration tests


## Notes for code reviewers

<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->
