### PR TITLE
CSS-17601: Add support for the timeout config option for CVE sync HTTP client.

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -20,11 +20,11 @@ parts:
       - requests
       - responses
     override-build: |
-      # 1. Install yq and GNU awk
-      snap install yq
+      # 1. Install yq and GNU awk.
+      sudo snap install yq
 
-      # 2. Run the default charm build steps
+      # 2. Run the default charm build steps.
       craftctl default
 
-      # 3. Get the image version and store it in the version file to be picked up by Juju
+      # 3. Get the image version and store it in the version file to be picked up by Juju.
       yq -r 'to_entries[] | select(.key == "resources") | .value[] | .["upstream-source"]? ' metadata.yaml | awk '{ match($0, /v[0-9]+(\.[0-9]+)*/, m); print m[0] }' | head -n1 > $CRAFT_PART_INSTALL/version

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,7 +11,7 @@ platforms:
     build-for: [amd64]
 parts:
   charm:
-    build-packages: [git]
+    build-packages: [git, gawk]
     charm-python-packages: [setuptools, pip]
     charm-binary-python-packages:
       - cosl
@@ -20,5 +20,11 @@ parts:
       - requests
       - responses
     override-build: |
+      # 1. Install yq and GNU awk
+      snap install yq
+
+      # 2. Run the default charm build steps
       craftctl default
+
+      # 3. Get the image version and store it in the version file to be picked up by Juju
       yq -r 'to_entries[] | select(.key == "resources") | .value[] | .["upstream-source"]? ' metadata.yaml | awk '{ match($0, /v[0-9]+(\.[0-9]+)*/, m); print m[0] }' | head -n1 > $CRAFT_PART_INSTALL/version

--- a/config.yaml
+++ b/config.yaml
@@ -319,6 +319,12 @@ options:
     default: "1h"
     description: Period between automatic refreshing of fixed CVE data.
     type: string
+  cve-sync.timeout:
+    default: "5m"
+    description: |
+      Timeout for the CVE sync client. The CVE sync will timeout if the CVE service
+      takes longer than the timeout defined, to send the CVE data.
+    type: string
   cve-sync.proxy.enabled:
     default: false
     description: Whether or not to proxy fixed CVE data syncs.

--- a/src/charm.py
+++ b/src/charm.py
@@ -494,28 +494,17 @@ class LivepatchCharm(CharmBase):
 
     def _get_db_info(self) -> Optional[Dict]:
         """Get database connection info by reading relation data."""
-        if (
-            len(self.database.relations) == 0
-            or not self.database.is_resource_created()
-        ):
-            LOGGER.debug(
-                "no (postgresql) database relation found or resource not created"
-            )
+        if len(self.database.relations) == 0 or not self.database.is_resource_created():
+            LOGGER.debug("no (postgresql) database relation found or resource not created")
             return None
 
         db_relation_id = self.database.relations[0].id
-        relation_data = self.database.fetch_relation_data().get(
-            db_relation_id, None
-        )
+        relation_data = self.database.fetch_relation_data().get(db_relation_id, None)
         if not relation_data:
-            LOGGER.debug(
-                "no relation data found for relation %s", db_relation_id
-            )
+            LOGGER.debug("no relation data found for relation %s", db_relation_id)
             return None
 
-        LOGGER.debug(
-            "database endpoints: %s", relation_data.get("endpoints")
-        )
+        LOGGER.debug("database endpoints: %s", relation_data.get("endpoints"))
         endpoint = relation_data.get("endpoints").split(",")[0]
         LOGGER.info("database endpoint: %s", endpoint)
         return {

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -2,12 +2,12 @@
 # See LICENSE file for licensing details.
 
 import logging
-import yaml
 import re
 import uuid
 from pathlib import Path
 from typing import Literal, Union
 
+import yaml
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from pytest_operator.plugin import OpsTest
 
@@ -138,7 +138,8 @@ def oci_image(metadata_file: str, image_name: str) -> str:
 
     return upstream_source
 
-def extract_version_from_metadata(path = 'metadata.yaml'):
+
+def extract_version_from_metadata(path="metadata.yaml"):
     """extract the version string from the metadata.yaml file."""
     with open(path) as f:
         metadata = yaml.safe_load(f)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,10 +3,10 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import os
+import pathlib
 import unittest
 from typing import Any, Dict, List
 from unittest.mock import Mock, patch
-import pathlib
 
 import yaml
 from ops import pebble
@@ -58,7 +58,7 @@ class TestCharm(unittest.TestCase):
         # create version file
         self.version_file = pathlib.Path("version")
         pathlib.Path.touch(self.version_file)
-        self.addCleanup( lambda: os.remove(self.version_file ) )
+        self.addCleanup(lambda: os.remove(self.version_file))
 
         self.harness.disable_hooks()
         self.harness.add_oci_resource("livepatch-server-image")
@@ -1302,6 +1302,7 @@ class TestCharm(unittest.TestCase):
                 "LP_CVE_SYNC_ENABLED": True,
                 "LP_CVE_SYNC_SOURCE_URL": "scheme://some.host.name:9999",
                 "LP_CVE_SYNC_INTERVAL": "1h",  # Default config value.
+                "LP_CVE_SYNC_TIMEOUT": "5m", # Default config value.
             }
         )
 
@@ -1338,6 +1339,7 @@ class TestCharm(unittest.TestCase):
                     "LP_CVE_SYNC_ENABLED": True,
                     "LP_CVE_SYNC_SOURCE_URL": "scheme://some.host.name:9999",
                     "LP_CVE_SYNC_INTERVAL": "1h",  # Default config value.
+                    "LP_CVE_SYNC_TIMEOUT": "5m", # Default config value.
                 }
             )
 


### PR DESCRIPTION
## Description

The timeout for the CVE sync HTTP client was not configurable and required configuring it in code and releasing. This PR aims to remove this overhead by making the timeout for the CVE sync HTTP client configurable through the Livepatch server charm.

This PR also adds a drive-by change to install the GNU awk and yq utilities that are used in the override-build step. These steps are required when  `charmcraft pack` is being run in an isolated environment.

Fixes *CSS-17601*

## Engineering checklist
*Check only items that apply*

- [ ] I have checked and added or updated relevant documentation.
- [ ] I have checked and added or updated relevant release notes.
- [x] Covered by unit tests
- [ ] Covered by integration tests


## Notes for code reviewers

The current charm builds run in destructive mode. This means that the builds run on the Canonical hosted github runner instead of an isolated LXD container or multipass VM. Should we change this behavior? @gaborbk @kunalmohan @trollLemon 
