### PR TITLE
Update optionality of endpoints in metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -31,8 +31,10 @@ peers:
 provides:
   grafana-dashboard:
     interface: grafana_dashboard
+    optional: true
   metrics-endpoint:
     interface: prometheus_scrape
+    optional: true
 
 requires:
   database-legacy:


### PR DESCRIPTION
## Description

### Issue

Since provides endpoints can be non-optional, can the default value of `optional` is [false](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/#endpoint-role-endpoint-name-optional), these endpoints are assumed non-optional.

### Solution

Set `optional` flag on provides endpoint to indicate correct optionality.

## Engineering checklist
*Check only items that apply*

- [ ] I have checked and added or updated relevant documentation.
- [ ] I have checked and added or updated relevant release notes.
- [ ] Covered by unit tests
- [ ] Covered by integration tests

