### PR TITLE
Config option for different ping buckets.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -387,6 +387,10 @@ options:
   influx.bucket:
     description: "Bucket to send data"
     type: string
+  influx.ping_bucket:
+    description: "Bucket to send ping data under a different retention policy"
+    type: string
+    
   influx.organization:
     description: "Organization name"
     type: string


### PR DESCRIPTION
## Description

This PR adds a new config option to set a different ping bucket for sending patch pings to influxdb.


## Engineering checklist
*Check only items that apply*

- [ ] I have checked and added or updated relevant documentation.
- [ ] I have checked and added or updated relevant release notes.
- [ ] Covered by unit tests
- [ ] Covered by integration tests


## Notes for code reviewers

<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->
