### PR TITLE
Add work_mem DB parameter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -117,7 +117,12 @@ options:
     description: The lifespan of an idle PostgreSQL connection.
     type: string
   database.work_mem:
-    description: The PostgreSQL work_mem parameter for connections with the database.
+    description: |
+      The PostgreSQL work_mem parameter for connections with the database.
+      The value is specified as an integer number of MegaBytes (MB), matching the
+      unit semantics of PostgreSQL's work_mem setting.
+      This option is optional: when left unset, the charm does not override
+      PostgreSQL's work_mem, and the server's own default value is used.
     type: int
 
   patch-storage.type:


### PR DESCRIPTION
## Description

Add `work_mem` config parameter for configuration work_mem for all connections to the PostgreSQL DB.

## Engineering checklist
*Check only items that apply*

- [ ] I have checked and added or updated relevant documentation.
- [ ] I have checked and added or updated relevant release notes.
- [ ] Covered by unit tests
- [ ] Covered by integration tests


## Notes for code reviewers

<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->
