### PR TITLE
CSS-22111: Fix timescale DB support in Livepatch server k8s charm.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -233,17 +233,17 @@ class LivepatchCharm(CharmBase):
         targets: Dict[str, str] = {}
 
         if self._state.dsn:
-            targets["primary"] = self._state.dsn
+            targets["livepatchdb"] = self._state.dsn
 
         if self._state.dsn_metrics:
-            targets["timescale"] = self._state.dsn_metrics
+            targets["timescaledb"] = self._state.dsn_metrics
 
         return targets
 
     def handle_schema_upgrade(self):
         """Check if a schema upgrade is required, and perform it."""
         targets = self._get_schema_upgrade_targets()
-        dsn = targets.get("primary")
+        dsn = targets.get("livepatchdb")
         if not dsn:
             LOGGER.info("waiting for PG connection string")
             self.unit.status = BlockedStatus("Waiting for postgres relation to be established.")
@@ -258,13 +258,13 @@ class LivepatchCharm(CharmBase):
         for db_name, conn_str in targets.items():
             upgrade_required = False
             try:
-                upgrade_required = self.migration_is_required(schema_container, conn_str)
+                upgrade_required = self.migration_is_required(schema_container, db_name, conn_str)
             except Exception as e:
                 LOGGER.error(f"Failed to determine if schema upgrade required for {db_name}: {e}")
 
             if upgrade_required:
                 try:
-                    self.schema_upgrade(schema_container, conn_str)
+                    self.schema_upgrade(schema_container, db_name, conn_str)
                 except Exception as e:
                     LOGGER.error(f"Failed to perform schema upgrade for {db_name}: {e}")
 
@@ -298,6 +298,7 @@ class LivepatchCharm(CharmBase):
 
         # Some extra config and checks
         env_vars["LP_DATABASE_CONNECTION_STRING"] = self._state.dsn
+        env_vars["LP_TIMESCALE_DB_CONNECTION_STRING"] = self._state.dsn_metrics
         env_vars["LP_SERVER_SERVER_ADDRESS"] = f":{SERVER_PORT}"
 
         if self.config.get("patch-storage.type") == "postgres":
@@ -310,7 +311,7 @@ class LivepatchCharm(CharmBase):
         env_vars = {key: value for key, value in env_vars.items() if value != "" and value is not None}
 
         # Keys that must be explicitly set even when empty, to override previous Pebble layer values.
-        explicit_keys = {"LP_CVE_SYNC_SOURCE_URL", "LP_LSN_SYNC_SOURCE_URL"}
+        explicit_keys = {"LP_CVE_SYNC_SOURCE_URL", "LP_LSN_SYNC_SOURCE_URL", "LP_TIMESCALE_DB_CONNECTION_STRING"}
         # Set keys to empty string if they are not already set.
         for key in explicit_keys:
             env_vars.setdefault(key, "")
@@ -766,7 +767,7 @@ class LivepatchCharm(CharmBase):
             return
 
         targets = self._get_schema_upgrade_targets()
-        db_uri = targets.get("primary")
+        db_uri = targets.get("livepatchdb")
         container = self.unit.get_container(SCHEMA_UPGRADE_CONTAINER)
         if not db_uri:
             LOGGER.error("DB connection string not set")
@@ -774,7 +775,7 @@ class LivepatchCharm(CharmBase):
             return
         
         if self.config.get("timescale_db.enabled"):
-            metrics_db_uri = targets.get("timescale")
+            metrics_db_uri = targets.get("timescaledb")
             if not metrics_db_uri:
                 LOGGER.error("Metrics DB connection string not set")
                 event.fail("schema migration failed: metrics database connection not set/ready")
@@ -787,12 +788,12 @@ class LivepatchCharm(CharmBase):
 
         for db_name, conn_str in targets.items():
             try:
-                self.schema_upgrade(container, conn_str)
+                self.schema_upgrade(container, db_name, conn_str)
             except Exception as e:
                 event.fail(f"schema migration failed for {db_name} database: {e}")
                 return
 
-    def schema_upgrade(self, container, conn_str):
+    def schema_upgrade(self, container, target, conn_str):
         """
         Perform a schema upgrade on the configurable database.
 
@@ -813,6 +814,8 @@ class LivepatchCharm(CharmBase):
                     "upgrade",
                     "--db",
                     conn_str,
+                    "--target",
+                    target,
                 ],
             )
         except pebble.APIError as e:
@@ -839,19 +842,35 @@ class LivepatchCharm(CharmBase):
             LOGGER.warning("State is not ready")
             return
 
-        db_uri = self._state.dsn
+        targets = self._get_schema_upgrade_targets()
         container = self.unit.get_container(SCHEMA_UPGRADE_CONTAINER)
+        db_uri = targets.get("livepatchdb")
+        if not db_uri:
+            LOGGER.error("DB connection string not set")
+            event.fail("schema migration failed: database connection not set/ready")
+            return
+        
+        if self.config.get("timescale_db.enabled"):
+            metrics_db_uri = targets.get("timescaledb")
+            if not metrics_db_uri:
+                LOGGER.error("Metrics DB connection string not set")
+                event.fail("schema migration failed: metrics database connection not set/ready")
+                return
+        
         if not container.can_connect():
-            LOGGER.error("cannot connect to the schema update container")
+            LOGGER.error("cannot connect to the schema upgrade container")
+            event.fail("schema migration failed: cannot connect to the schema upgrade container")
             return
 
-        try:
-            migration_required = self.migration_is_required(container, db_uri)
-            event.set_results({"migration-required": migration_required})
-        except Exception as e:
-            event.fail(f"schema version check failed: {e}")
+        for db_name, conn_str in targets.items():
+            try:
+                migration_required = self.migration_is_required(container, db_name,  conn_str)
+                event.set_results({f"migration-required-{db_name}": migration_required})
+            except Exception as e:
+                event.fail(f"schema version check failed for {db_name}: {e}")
+                return
 
-    def migration_is_required(self, container, conn_str: str) -> bool:
+    def migration_is_required(self, container, target, conn_str: str) -> bool:
         """Run a schema version check against the database."""
         if not container.exists("/usr/local/bin/livepatch-schema-tool"):
             LOGGER.error("livepatch-schema-tool not found in the schema upgrade container")
@@ -869,6 +888,8 @@ class LivepatchCharm(CharmBase):
                     "check",
                     "--db",
                     conn_str,
+                    "--target",
+                    target,
                 ],
             )
         except pebble.APIError as e:

--- a/src/charm.py
+++ b/src/charm.py
@@ -773,7 +773,7 @@ class LivepatchCharm(CharmBase):
             LOGGER.error("DB connection string not set")
             event.fail("schema migration failed: database connection not set/ready")
             return
-        
+
         if self.config.get("timescale_db.enabled"):
             metrics_db_uri = targets.get("timescaledb")
             if not metrics_db_uri:
@@ -849,14 +849,14 @@ class LivepatchCharm(CharmBase):
             LOGGER.error("DB connection string not set")
             event.fail("schema migration failed: database connection not set/ready")
             return
-        
+
         if self.config.get("timescale_db.enabled"):
             metrics_db_uri = targets.get("timescaledb")
             if not metrics_db_uri:
                 LOGGER.error("Metrics DB connection string not set")
                 event.fail("schema migration failed: metrics database connection not set/ready")
                 return
-        
+
         if not container.can_connect():
             LOGGER.error("cannot connect to the schema upgrade container")
             event.fail("schema migration failed: cannot connect to the schema upgrade container")
@@ -864,7 +864,7 @@ class LivepatchCharm(CharmBase):
 
         for db_name, conn_str in targets.items():
             try:
-                migration_required = self.migration_is_required(container, db_name,  conn_str)
+                migration_required = self.migration_is_required(container, db_name, conn_str)
                 event.set_results({f"migration-required-{db_name}": migration_required})
             except Exception as e:
                 event.fail(f"schema version check failed for {db_name}: {e}")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -205,6 +205,8 @@ class TestCharm(unittest.TestCase):
                     "upgrade",
                     "--db",
                     "postgresql://123",
+                    "--target",
+                    "livepatchdb",
                 ],
             )
             process_mock = Mock()
@@ -242,6 +244,8 @@ class TestCharm(unittest.TestCase):
                     "upgrade",
                     "--db",
                     "postgresql://123",
+                    "--target",
+                    "livepatchdb",
                 ],
             )
 
@@ -259,7 +263,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             ex.exception.message,
-            "schema migration failed for primary database: non-zero exit code 1 executing '/usr/local/bin/livepatch-schema-tool', stdout='', stderr='some error'",
+            "schema migration failed for livepatchdb database: non-zero exit code 1 executing '/usr/local/bin/livepatch-schema-tool', stdout='', stderr='some error'",
         )
 
 
@@ -340,6 +344,8 @@ class TestCharm(unittest.TestCase):
                     "check",
                     "--db",
                     "postgresql://123",
+                    "--target",
+                    "livepatchdb",
                 ],
             )
             process_mock = Mock()
@@ -350,7 +356,7 @@ class TestCharm(unittest.TestCase):
 
         output = self.harness.run_action("schema-version")
 
-        self.assertEqual(output.results, {"migration-required": False})
+        self.assertEqual(output.results, {"migration-required-livepatchdb": False})
 
     def test_schema_version_action__success__migration_required(self):
         """
@@ -379,6 +385,8 @@ class TestCharm(unittest.TestCase):
                     "check",
                     "--db",
                     "postgresql://123",
+                    "--target",
+                    "livepatchdb",
                 ],
             )
 
@@ -393,7 +401,7 @@ class TestCharm(unittest.TestCase):
 
         output = self.harness.run_action("schema-version")
 
-        self.assertEqual(output.results, {"migration-required": True})
+        self.assertEqual(output.results, {"migration-required-livepatchdb": True})
 
     def test_schema_version_action__failure(self):
         """Test the scenario where `schema-version` action fails."""
@@ -419,6 +427,8 @@ class TestCharm(unittest.TestCase):
                     "check",
                     "--db",
                     "postgresql://123",
+                    "--target",
+                    "livepatchdb",
                 ],
             )
 
@@ -436,7 +446,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             ex.exception.message,
-            "schema version check failed: non-zero exit code 1 executing '/usr/local/bin/livepatch-schema-tool', stdout='', stderr='some error'",
+            "schema version check failed for livepatchdb: non-zero exit code 1 executing '/usr/local/bin/livepatch-schema-tool', stdout='', stderr='some error'",
         )
 
     def test_get_resource_token_action__success(self):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -266,7 +266,6 @@ class TestCharm(unittest.TestCase):
             "schema migration failed for livepatchdb database: non-zero exit code 1 executing '/usr/local/bin/livepatch-schema-tool', stdout='', stderr='some error'",
         )
 
-
     def test_on_config_changed__failure__cannot_connect_to_schema_upgrade_container(self):
         """
         Test the scenario where `on-config-changed` event handler fails due to

--- a/tests/unit/test_timescale_db.py
+++ b/tests/unit/test_timescale_db.py
@@ -3,13 +3,13 @@
 
 """Additional unit tests specifically for MetricsDB functionality."""
 
-from typing import Any, Dict
-import unittest
-from unittest.mock import Mock, patch
-import pathlib
 import os
+import pathlib
+import unittest
+from typing import Any, Dict
+from unittest.mock import Mock, patch
 
-from ops.testing import Harness, ActionFailed
+from ops.testing import ActionFailed, Harness
 
 from src.charm import LivepatchCharm
 
@@ -17,6 +17,7 @@ TEST_TOKEN = "test-token"  # nosec
 APP_NAME = "canonical-livepatch-server-k8s"
 
 
+# pylint: disable=too-many-public-methods
 class TestMetricsDBFunctionality(unittest.TestCase):
     """Test MetricsDB specific functionality."""
 
@@ -101,7 +102,6 @@ class TestMetricsDBFunctionality(unittest.TestCase):
         with patch.object(self.harness.charm.metrics_db, "is_resource_created", return_value=True), patch.object(
             self.harness.charm.metrics_db, "fetch_relation_data", return_value=mock_relation_data
         ):
-
             db_info = self.harness.charm._get_db_info(self.harness.charm.metrics_db)
 
             self.assertIsNotNone(db_info)
@@ -125,7 +125,6 @@ class TestMetricsDBFunctionality(unittest.TestCase):
         with patch.object(self.harness.charm.metrics_db, "is_resource_created", return_value=True), patch.object(
             self.harness.charm.metrics_db, "fetch_relation_data", return_value={}
         ):
-
             db_info = self.harness.charm._get_db_info(self.harness.charm.metrics_db)
             self.assertIsNone(db_info)
 
@@ -191,7 +190,7 @@ class TestMetricsDBFunctionality(unittest.TestCase):
         )
 
         self.harness.charm._on_metrics_db_event(Mock(relation=Mock(name="metrics-db")))
-    
+
         expected_dsn = "postgresql://tsuser:tspass@postgres.local:5432/livepatch-metrics-db"
         self.assertEqual(self.harness.charm._state.dsn_metrics, expected_dsn)
 
@@ -473,10 +472,14 @@ class TestMetricsDBFunctionality(unittest.TestCase):
         self.harness.charm._state.dsn_metrics = "postgresql://tsuser:tspass@postgres.local:5432/livepatch-metrics-db"
         self.harness.charm.on.config_changed.emit()
 
-        environment = self.harness.get_container_pebble_plan("livepatch").to_dict()["services"]["livepatch"]["environment"]
+        environment = self.harness.get_container_pebble_plan("livepatch").to_dict()["services"]["livepatch"][
+            "environment"
+        ]
         self.assertIn("LP_TIMESCALE_DB_CONNECTION_STRING", environment)
 
         self.harness.charm._on_metrics_db_relation_broken(Mock())
 
-        environment = self.harness.get_container_pebble_plan("livepatch").to_dict()["services"]["livepatch"]["environment"]
+        environment = self.harness.get_container_pebble_plan("livepatch").to_dict()["services"]["livepatch"][
+            "environment"
+        ]
         self.assertEqual(environment.get("LP_TIMESCALE_DB_CONNECTION_STRING"), "")

--- a/tests/unit/test_timescale_db.py
+++ b/tests/unit/test_timescale_db.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 import pathlib
 import os
 
+from ops._private.harness import ActionFailed
 from ops.testing import Harness
 
 from src.charm import LivepatchCharm
@@ -143,12 +144,16 @@ class TestMetricsDBFunctionality(unittest.TestCase):
                 self.harness.charm.handle_schema_upgrade()
 
         self.assertEqual(migration.call_count, 2)
-        self.assertEqual(migration.call_args_list[0].args[1], "postgresql://primary")
-        self.assertEqual(migration.call_args_list[1].args[1], "postgresql://timescale")
+        self.assertEqual(migration.call_args_list[0].args[1], "livepatchdb")
+        self.assertEqual(migration.call_args_list[0].args[2], "postgresql://primary")
+        self.assertEqual(migration.call_args_list[1].args[1], "timescaledb")
+        self.assertEqual(migration.call_args_list[1].args[2], "postgresql://timescale")
 
         self.assertEqual(schema_upgrade.call_count, 2)
-        self.assertEqual(schema_upgrade.call_args_list[0].args[1], "postgresql://primary")
-        self.assertEqual(schema_upgrade.call_args_list[1].args[1], "postgresql://timescale")
+        self.assertEqual(schema_upgrade.call_args_list[0].args[1], "livepatchdb")
+        self.assertEqual(schema_upgrade.call_args_list[0].args[2], "postgresql://primary")
+        self.assertEqual(schema_upgrade.call_args_list[1].args[1], "timescaledb")
+        self.assertEqual(schema_upgrade.call_args_list[1].args[2], "postgresql://timescale")
 
     def test_schema_upgrade_action_runs_for_timescale_when_enabled(self):
         """Test schema-upgrade action upgrades both primary and Timescale databases."""
@@ -164,8 +169,10 @@ class TestMetricsDBFunctionality(unittest.TestCase):
             self.harness.run_action("schema-upgrade")
 
         self.assertEqual(schema_upgrade.call_count, 2)
-        self.assertEqual(schema_upgrade.call_args_list[0].args[1], "postgresql://primary")
-        self.assertEqual(schema_upgrade.call_args_list[1].args[1], "postgresql://timescale")
+        self.assertEqual(schema_upgrade.call_args_list[0].args[1], "livepatchdb")
+        self.assertEqual(schema_upgrade.call_args_list[0].args[2], "postgresql://primary")
+        self.assertEqual(schema_upgrade.call_args_list[1].args[1], "timescaledb")
+        self.assertEqual(schema_upgrade.call_args_list[1].args[2], "postgresql://timescale")
 
     def test_metrics_db_event_handles_relation_created(self):
         """Test MetricsDB relation created event is handled properly."""
@@ -196,6 +203,16 @@ class TestMetricsDBFunctionality(unittest.TestCase):
 
         metrics_rel_id = self.harness.add_relation("metrics-db", "postgresql")
         self.harness.add_relation_unit(metrics_rel_id, "postgresql/0")
+        self.harness.update_relation_data(
+            metrics_rel_id,
+            "postgresql",
+            {
+                "endpoints": "postgres.local:5432",
+                "username": "tsuser",
+                "password": "tspass",  # nosec B105
+            },
+        )
+        self.harness.charm._on_metrics_db_event(Mock(relation=Mock(name="metrics-db")))
 
         self.harness.update_config(
             {
@@ -211,6 +228,7 @@ class TestMetricsDBFunctionality(unittest.TestCase):
         self._assert_environment_contains(
             {
                 "LP_TIMESCALE_DB_ENABLED": True,
+                "LP_TIMESCALE_DB_CONNECTION_STRING": "postgresql://tsuser:tspass@postgres.local:5432/livepatch-metrics-db",
                 "LP_TIMESCALE_DB_CONNECTION_POOL_MAX": 20,
                 "LP_TIMESCALE_DB_CONNECTION_LIFETIME_MAX": "30m",
                 "LP_TIMESCALE_DB_WORK_MEM": 32,
@@ -233,7 +251,9 @@ class TestMetricsDBFunctionality(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan("livepatch")
         environment = plan.to_dict()["services"]["livepatch"]["environment"]
 
-        self.assertNotIn("LP_TIMESCALE_DB_CONNECTION_STRING", environment)
+        # LP_TIMESCALE_DB_CONNECTION_STRING is explicitly set to "" when no metrics-db relation exists,
+        # so that any previously set value is cleared from the Pebble layer (override: merge semantics).
+        self.assertEqual(environment.get("LP_TIMESCALE_DB_CONNECTION_STRING"), "")
 
     def test_metrics_db_event_defers_when_no_db_info(self):
         """Test MetricsDB event is deferred when database info is not available."""
@@ -310,3 +330,154 @@ class TestMetricsDBFunctionality(unittest.TestCase):
         self.assertEqual(environment["LP_TIMESCALE_DB_CONNECTION_LIFETIME_MAX"], "10m")
         self.assertIn("LP_TIMESCALE_DB_WORK_MEM", environment)
         self.assertEqual(environment["LP_TIMESCALE_DB_WORK_MEM"], 16)
+
+    def test_lp_timescale_db_connection_string_set_when_dsn_metrics_available(self):
+        """Test LP_TIMESCALE_DB_CONNECTION_STRING env var is set when dsn_metrics is available."""
+        self.harness.set_leader(True)
+        self.start_container()
+
+        self.harness.charm._state.dsn_metrics = "postgresql://tsuser:tspass@postgres.local:5432/livepatch-metrics-db"
+
+        self.harness.charm.on.config_changed.emit()
+
+        self._assert_environment_contains(
+            {"LP_TIMESCALE_DB_CONNECTION_STRING": "postgresql://tsuser:tspass@postgres.local:5432/livepatch-metrics-db"}
+        )
+
+    def test_lp_timescale_db_connection_string_empty_when_no_dsn_metrics(self):
+        """Test LP_TIMESCALE_DB_CONNECTION_STRING is set to empty string when dsn_metrics is not set.
+
+        The key is explicitly present as "" to override any previously set value in the Pebble layer
+        (required because the service uses override: merge semantics).
+        """
+        self.harness.set_leader(True)
+        self.start_container()
+
+        self.harness.charm._state.dsn_metrics = None
+
+        self.harness.charm.on.config_changed.emit()
+
+        plan = self.harness.get_container_pebble_plan("livepatch")
+        environment = plan.to_dict()["services"]["livepatch"]["environment"]
+        self.assertEqual(environment.get("LP_TIMESCALE_DB_CONNECTION_STRING"), "")
+
+    def test_get_schema_upgrade_targets_includes_livepatchdb_key(self):
+        """Test _get_schema_upgrade_targets uses 'livepatchdb' as the primary DB key."""
+        self.harness.charm._state.dsn = "postgresql://primary"
+        self.harness.charm._state.dsn_metrics = None
+
+        targets = self.harness.charm._get_schema_upgrade_targets()
+
+        self.assertIn("livepatchdb", targets)
+        self.assertEqual(targets["livepatchdb"], "postgresql://primary")
+        self.assertNotIn("timescaledb", targets)
+
+    def test_get_schema_upgrade_targets_includes_timescaledb_key_when_metrics_present(self):
+        """Test _get_schema_upgrade_targets uses 'timescaledb' as the metrics DB key."""
+        self.harness.charm._state.dsn = "postgresql://primary"
+        self.harness.charm._state.dsn_metrics = "postgresql://timescale"
+
+        targets = self.harness.charm._get_schema_upgrade_targets()
+
+        self.assertIn("livepatchdb", targets)
+        self.assertEqual(targets["livepatchdb"], "postgresql://primary")
+        self.assertIn("timescaledb", targets)
+        self.assertEqual(targets["timescaledb"], "postgresql://timescale")
+
+    def test_schema_version_action_checks_both_dbs_when_timescale_enabled(self):
+        """Test schema-version action checks both databases when timescale_db.enabled=True."""
+        self.harness.set_leader(True)
+        self.start_container()
+
+        self.harness.charm._state.dsn_metrics = "postgresql://tsuser:tspass@postgres.local:5432/livepatch-metrics-db"
+        self.harness.update_config({"timescale_db.enabled": True})
+
+        schema_upgrade_container = self.harness.model.unit.get_container("livepatch-schema-upgrade")
+        schema_upgrade_container.exists = Mock(return_value=True)
+
+        call_index = [0]
+        expected_commands = [
+            ["/usr/local/bin/livepatch-schema-tool", "check", "--db", "postgresql://123", "--target", "livepatchdb"],
+            [
+                "/usr/local/bin/livepatch-schema-tool",
+                "check",
+                "--db",
+                "postgresql://tsuser:tspass@postgres.local:5432/livepatch-metrics-db",
+                "--target",
+                "timescaledb",
+            ],
+        ]
+
+        def container_exec_side_effect(command):
+            self.assertEqual(command, expected_commands[call_index[0]])
+            call_index[0] += 1
+            process_mock = Mock()
+            process_mock.wait_output.return_value = (None, None)
+            return process_mock
+
+        schema_upgrade_container.exec = Mock(side_effect=container_exec_side_effect)
+
+        output = self.harness.run_action("schema-version")
+
+        self.assertEqual(schema_upgrade_container.exec.call_count, 2)
+        self.assertFalse(output.results["migration-required-livepatchdb"])
+        self.assertFalse(output.results["migration-required-timescaledb"])
+
+    def test_schema_version_action_fails_when_timescale_enabled_but_no_dsn_metrics(self):
+        """Test schema-version action fails when timescale_db.enabled=True but no metrics relation."""
+        self.harness.set_leader(True)
+        self.start_container()
+
+        self.harness.charm._state.dsn_metrics = None
+        self.harness.update_config({"timescale_db.enabled": True})
+
+        with self.assertRaises(ActionFailed) as ex:
+            self.harness.run_action("schema-version")
+
+        self.assertIn("metrics database connection not set/ready", ex.exception.message)
+
+    def test_schema_upgrade_action_fails_when_timescale_enabled_but_no_dsn_metrics(self):
+        """Test schema-upgrade action fails when timescale_db.enabled=True but no metrics relation."""
+        self.harness.set_leader(True)
+        self.start_container()
+
+        self.harness.charm._state.dsn_metrics = None
+        self.harness.update_config({"timescale_db.enabled": True})
+
+        with self.assertRaises(ActionFailed) as ex:
+            self.harness.run_action("schema-upgrade")
+
+        self.assertIn("metrics database connection not set/ready", ex.exception.message)
+
+    def test_handle_schema_upgrade_runs_timescale_regardless_of_config_flag(self):
+        """Test handle_schema_upgrade runs for timescaleDB based on dsn_metrics alone, ignoring config flag."""
+        self.harness.charm._state.dsn = "postgresql://primary"
+        self.harness.charm._state.dsn_metrics = "postgresql://timescale"
+        self.harness.model.unit.get_container("livepatch-schema-upgrade").can_connect = lambda: True
+        self.harness.update_config({"timescale_db.enabled": False})
+
+        with patch("src.charm.LivepatchCharm.migration_is_required", return_value=True) as migration:
+            with patch("src.charm.LivepatchCharm.schema_upgrade") as schema_upgrade:
+                self.harness.charm.handle_schema_upgrade()
+
+        self.assertEqual(migration.call_count, 2)
+        self.assertEqual(schema_upgrade.call_count, 2)
+        db_names = [call.args[1] for call in schema_upgrade.call_args_list]
+        self.assertIn("livepatchdb", db_names)
+        self.assertIn("timescaledb", db_names)
+
+    def test_metrics_db_relation_broken_clears_connection_string_from_env(self):
+        """Test _on_metrics_db_relation_broken removes LP_TIMESCALE_DB_CONNECTION_STRING from env."""
+        self.harness.set_leader(True)
+        self.start_container()
+
+        self.harness.charm._state.dsn_metrics = "postgresql://tsuser:tspass@postgres.local:5432/livepatch-metrics-db"
+        self.harness.charm.on.config_changed.emit()
+
+        environment = self.harness.get_container_pebble_plan("livepatch").to_dict()["services"]["livepatch"]["environment"]
+        self.assertIn("LP_TIMESCALE_DB_CONNECTION_STRING", environment)
+
+        self.harness.charm._on_metrics_db_relation_broken(Mock())
+
+        environment = self.harness.get_container_pebble_plan("livepatch").to_dict()["services"]["livepatch"]["environment"]
+        self.assertEqual(environment.get("LP_TIMESCALE_DB_CONNECTION_STRING"), "")

--- a/tests/unit/test_timescale_db.py
+++ b/tests/unit/test_timescale_db.py
@@ -9,8 +9,7 @@ from unittest.mock import Mock, patch
 import pathlib
 import os
 
-from ops._private.harness import ActionFailed
-from ops.testing import Harness
+from ops.testing import Harness, ActionFailed
 
 from src.charm import LivepatchCharm
 


### PR DESCRIPTION
## Description

The Livepatch server K8s charm was running schema upgrades using the livepatch DB target irrespective of the relation. This PR updates the charm code to run upgrades for specific targets and also set the connection string for the Timescale DB in the environment variables.

Changes have also been made to the schema upgrade and schema version check actions to handle the various error cases and keep them consistent.

Fixes *CSS-22111*

## Engineering checklist
*Check only items that apply*

- [ ] I have checked and added or updated relevant documentation.
- [ ] I have checked and added or updated relevant release notes.
- [x] Covered by unit tests
- [ ] Covered by integration tests


## Notes for code reviewers

<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->
