### PR TITLE
Pass proxy env vars into container environment with standard names

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -309,6 +309,11 @@ class LivepatchCharm(CharmBase):
         # remove empty environment values
         env_vars = {key: value for key, value in env_vars.items() if value != "" and value is not None}
 
+        # set proxy environment variables (without the LP_ prefix)
+        proxy_dict = utils.get_proxy_dict(self.config)
+        if proxy_dict:
+            env_vars.update(proxy_dict)
+
         # Keys that must be explicitly set even when empty, to override previous Pebble layer values.
         explicit_keys = {"LP_CVE_SYNC_SOURCE_URL", "LP_LSN_SYNC_SOURCE_URL"}
         # Set keys to empty string if they are not already set.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1453,6 +1453,43 @@ settings:
                 },
             )
 
+    def test_proxy_env_vars_from_juju_env(self):
+        """Test that JUJU_CHARM_* proxy env vars are mapped into the pebble environment."""
+        self.harness.set_leader(True)
+        self.harness.enable_hooks()
+
+        juju_proxy_env = {
+            "JUJU_CHARM_HTTP_PROXY": "http://proxy.example.com:3128",
+            "JUJU_CHARM_HTTPS_PROXY": "https://proxy.example.com:3128",
+            "JUJU_CHARM_NO_PROXY": "localhost,127.0.0.1",
+        }
+        with patch.dict(os.environ, juju_proxy_env, clear=False):
+            self.start_container()
+
+        self._assert_environment_contains(
+            {
+                "http_proxy": "http://proxy.example.com:3128",
+                "https_proxy": "https://proxy.example.com:3128",
+                "no_proxy": "localhost,127.0.0.1",
+            }
+        )
+
+    def test_proxy_env_vars_absent_when_not_configured(self):
+        """Test that proxy env vars are not set when neither config nor JUJU env vars are present."""
+        self.harness.set_leader(True)
+        self.harness.enable_hooks()
+
+        # Ensure JUJU proxy env vars are not set
+        proxy_keys = ["JUJU_CHARM_HTTP_PROXY", "JUJU_CHARM_HTTPS_PROXY", "JUJU_CHARM_NO_PROXY"]
+        env_without_proxy = {k: "" for k in proxy_keys}
+        with patch.dict(os.environ, env_without_proxy, clear=False):
+            self.start_container()
+
+        plan = self.harness.get_container_pebble_plan("livepatch")
+        environment = plan.to_dict()["services"]["livepatch"]["environment"]
+        for key in ("http_proxy", "https_proxy", "no_proxy"):
+            self.assertNotIn(key, environment)
+
     def _assert_environment_contains(self, contains: Dict[str, Any]):
         """Assert Pebble plan environment contains given key/value pairs."""
         plan = self.harness.get_container_pebble_plan("livepatch")


### PR DESCRIPTION
## Description

This PR fixes an issue where proxy env variables, HTTP_PROXY, HTTPS_PROXY, NO_PROXY, weren't passed into the container environment with standard naming conventions. They are passed for certain livepatch server components, but prefixed with `LP_`.  The livepatch-server's swift object storage library reads the proxy config from env variables, so we need to pass the proxy config with standard naming conventions, along with the prefixed ones. 

Fixes *JIRA/GitHub issue number*

## Engineering checklist
*Check only items that apply*

- [ ] I have checked and added or updated relevant documentation.
- [ ] I have checked and added or updated relevant release notes.
- [ ] Covered by unit tests
- [ ] Covered by integration tests


## Notes for code reviewers

<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->
