### PR TITLE
workaround for pg-bouncer issue [WIP]

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -28,7 +28,7 @@ jobs:
           juju-channel: 2.9/stable
           provider: microk8s
           microk8s-group: snap_microk8s
-          microk8s-addons: "ingress storage dns rbac registry metallb:192.168.1.100-192.168.1.100"
+          microk8s-addons: "ingress storage dns rbac registry"
           # Workaround for juju 2.9.58. ref: https://github.com/juju/juju/issues/22356#issuecomment-4340119766
           bootstrap-options: "--config caas-image-repo=ghcr.io/juju"
       # Instructions from https://microk8s.io/docs/registry-private

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,6 +7,7 @@
 """Livepatch k8s charm."""
 
 import pathlib
+import time
 from base64 import b64decode
 from typing import Dict, Optional
 from urllib.parse import ParseResult, urlunparse
@@ -53,6 +54,34 @@ TRUSTED_CA_FILENAME = "/usr/local/share/ca-certificates/trusted-contracts.ca.crt
 
 class DeferError(Exception):
     """An exception that indicates the event should be deferred."""
+
+
+class TransientSchemaToolError(Exception):
+    """A schema-tool failure caused by a transient pgbouncer/pgx condition.
+
+    These errors clear once a fresh backend connection is taken from the
+    pgbouncer pool, so they should be retried (and ultimately deferred) rather
+    than treated as fatal. See:
+      - livepatch-k8s-operator#96   (prepared statement "lrupsc_*" already exists, 42P05)
+      - pgbouncer-k8s-operator#740  (DISCARD ALL cannot run inside a transaction block, 25001)
+    """
+
+
+# Substrings identifying schema-tool errors that are transient when the
+# database is reached through pgbouncer (session pooling). pgx prepares named
+# statements that collide on reused backend connections (42P05), and a
+# connection left mid-transaction trips pgbouncer's server_reset_query (25001).
+TRANSIENT_SCHEMA_TOOL_MARKERS = (
+    "SQLSTATE 42P05",
+    "already exists",
+    "SQLSTATE 25001",
+    "DISCARD ALL cannot run inside a transaction block",
+)
+# Number of times to re-run the schema tool on a transient error before giving
+# up (and deferring the hook so Juju retries later).
+SCHEMA_TOOL_MAX_ATTEMPTS = 5
+# Delay between schema-tool retries, in seconds.
+SCHEMA_TOOL_RETRY_DELAY = 3
 
 
 class LivepatchCharm(CharmBase):
@@ -259,12 +288,20 @@ class LivepatchCharm(CharmBase):
             upgrade_required = False
             try:
                 upgrade_required = self.migration_is_required(schema_container, conn_str)
+            except TransientSchemaToolError as e:
+                LOGGER.warning("transient db error while checking schema for %s, deferring: %s", db_name, e)
+                self.unit.status = WaitingStatus("Waiting for database to settle (pgbouncer)")
+                raise DeferError() from e
             except Exception as e:
                 LOGGER.error(f"Failed to determine if schema upgrade required for {db_name}: {e}")
 
             if upgrade_required:
                 try:
                     self.schema_upgrade(schema_container, conn_str)
+                except TransientSchemaToolError as e:
+                    LOGGER.warning("transient db error while upgrading schema for %s, deferring: %s", db_name, e)
+                    self.unit.status = WaitingStatus("Waiting for database to settle (pgbouncer)")
+                    raise DeferError() from e
                 except Exception as e:
                     LOGGER.error(f"Failed to perform schema upgrade for {db_name}: {e}")
 
@@ -772,7 +809,7 @@ class LivepatchCharm(CharmBase):
             LOGGER.error("DB connection string not set")
             event.fail("schema migration failed: database connection not set/ready")
             return
-        
+
         if self.config.get("timescale_db.enabled"):
             metrics_db_uri = targets.get("timescale")
             if not metrics_db_uri:
@@ -792,12 +829,23 @@ class LivepatchCharm(CharmBase):
                 event.fail(f"schema migration failed for {db_name} database: {e}")
                 return
 
+    @staticmethod
+    def _is_transient_schema_tool_error(stderr: Optional[str]) -> bool:
+        """Return True if the schema-tool stderr indicates a transient pgbouncer error."""
+        if not stderr:
+            return False
+        return any(marker in stderr for marker in TRANSIENT_SCHEMA_TOOL_MARKERS)
+
     def schema_upgrade(self, container, conn_str):
         """
         Perform a schema upgrade on the configurable database.
 
         Raise an exception if there is a failure to prevent further charm.
         hook from firing and prevent more non-leader units from upgrading.
+
+        Transient pgbouncer errors (see TRANSIENT_SCHEMA_TOOL_MARKERS) are
+        retried; if they persist a TransientSchemaToolError is raised so the
+        caller can defer rather than treat the failure as fatal.
         """
         LOGGER.info("Attempting schema upgrade")
         self.unit.status = WaitingStatus("pg connection successful, attempting upgrade")
@@ -805,32 +853,45 @@ class LivepatchCharm(CharmBase):
             LOGGER.error("livepatch-schema-tool not found in the schema upgrade container")
             raise FileNotFoundError("schema tool not found")
 
-        process = None
-        try:
-            process = container.exec(
-                command=[
-                    "/usr/local/bin/livepatch-schema-tool",
-                    "upgrade",
-                    "--db",
-                    conn_str,
-                ],
-            )
-        except pebble.APIError as e:
-            LOGGER.error(e)
-            LOGGER.error("Schema migration failed")
-            raise e
+        for attempt in range(1, SCHEMA_TOOL_MAX_ATTEMPTS + 1):
+            try:
+                process = container.exec(
+                    command=[
+                        "/usr/local/bin/livepatch-schema-tool",
+                        "upgrade",
+                        "--db",
+                        conn_str,
+                    ],
+                )
+            except pebble.APIError as e:
+                LOGGER.error(e)
+                LOGGER.error("Schema migration failed")
+                raise e
 
-        try:
-            stdout, _ = process.wait_output()
-            LOGGER.info(stdout)
-            self.unit.status = WaitingStatus("Schema migration done")
-        except pebble.ExecError as e:
-            LOGGER.error(e)
-            LOGGER.error("Exited with code %d. Stderr:", e.exit_code)
-            for line in e.stderr.splitlines():
-                LOGGER.error("    %s", line)
-            LOGGER.error("Schema migration failed - executing migration failed")
-            raise e
+            try:
+                stdout, _ = process.wait_output()
+                LOGGER.info(stdout)
+                self.unit.status = WaitingStatus("Schema migration done")
+                return
+            except pebble.ExecError as e:
+                if self._is_transient_schema_tool_error(e.stderr):
+                    if attempt < SCHEMA_TOOL_MAX_ATTEMPTS:
+                        LOGGER.warning(
+                            "transient db error during schema upgrade (attempt %d/%d), retrying in %ds",
+                            attempt,
+                            SCHEMA_TOOL_MAX_ATTEMPTS,
+                            SCHEMA_TOOL_RETRY_DELAY,
+                        )
+                        time.sleep(SCHEMA_TOOL_RETRY_DELAY)
+                        continue
+                    LOGGER.error("Schema migration still failing after %d attempts", attempt)
+                    raise TransientSchemaToolError(e.stderr) from e
+                LOGGER.error(e)
+                LOGGER.error("Exited with code %d. Stderr:", e.exit_code)
+                for line in e.stderr.splitlines():
+                    LOGGER.error("    %s", line)
+                LOGGER.error("Schema migration failed - executing migration failed")
+                raise e
 
     def schema_version_check_action(self, event: ActionEvent):
         """Check schema version action."""
@@ -861,33 +922,46 @@ class LivepatchCharm(CharmBase):
             LOGGER.error("Database connection string not found")
             raise ValueError("Database connection string is None")
 
-        process = None
-        try:
-            process = container.exec(
-                command=[
-                    "/usr/local/bin/livepatch-schema-tool",
-                    "check",
-                    "--db",
-                    conn_str,
-                ],
-            )
-        except pebble.APIError as e:
-            LOGGER.error(e)
-            raise e
+        for attempt in range(1, SCHEMA_TOOL_MAX_ATTEMPTS + 1):
+            try:
+                process = container.exec(
+                    command=[
+                        "/usr/local/bin/livepatch-schema-tool",
+                        "check",
+                        "--db",
+                        conn_str,
+                    ],
+                )
+            except pebble.APIError as e:
+                LOGGER.error(e)
+                raise e
 
-        stdout = None
-        try:
-            stdout, _ = process.wait_output()
-            LOGGER.info("Schema is up to date.")
-            LOGGER.info(stdout)
-            return False
-        except pebble.ExecError as e:
-            LOGGER.info(e.stderr)
-            if e.exit_code == 2:
-                # If command has a non-zero exit code then migrations are pending.
-                LOGGER.info("Migrations pending")
-                return True
-            raise e
+            try:
+                stdout, _ = process.wait_output()
+                LOGGER.info("Schema is up to date.")
+                LOGGER.info(stdout)
+                return False
+            except pebble.ExecError as e:
+                LOGGER.info(e.stderr)
+                if e.exit_code == 2:
+                    # If command has a non-zero exit code then migrations are pending.
+                    LOGGER.info("Migrations pending")
+                    return True
+                if self._is_transient_schema_tool_error(e.stderr):
+                    if attempt < SCHEMA_TOOL_MAX_ATTEMPTS:
+                        LOGGER.warning(
+                            "transient db error during schema check (attempt %d/%d), retrying in %ds",
+                            attempt,
+                            SCHEMA_TOOL_MAX_ATTEMPTS,
+                            SCHEMA_TOOL_RETRY_DELAY,
+                        )
+                        time.sleep(SCHEMA_TOOL_RETRY_DELAY)
+                        continue
+                    LOGGER.error("Schema check still failing after %d attempts", attempt)
+                    raise TransientSchemaToolError(e.stderr) from e
+                raise e
+        # Unreachable: the loop either returns or raises on every path.
+        raise RuntimeError("schema check retry loop exited unexpectedly")
 
     def get_resource_token_action(self, event: ActionEvent):
         """Retrieve the livepatch resource token from ua-contracts."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -262,17 +262,17 @@ class LivepatchCharm(CharmBase):
         targets: Dict[str, str] = {}
 
         if self._state.dsn:
-            targets["primary"] = self._state.dsn
+            targets["livepatchdb"] = self._state.dsn
 
         if self._state.dsn_metrics:
-            targets["timescale"] = self._state.dsn_metrics
+            targets["timescaledb"] = self._state.dsn_metrics
 
         return targets
 
     def handle_schema_upgrade(self):
         """Check if a schema upgrade is required, and perform it."""
         targets = self._get_schema_upgrade_targets()
-        dsn = targets.get("primary")
+        dsn = targets.get("livepatchdb")
         if not dsn:
             LOGGER.info("waiting for PG connection string")
             self.unit.status = BlockedStatus("Waiting for postgres relation to be established.")
@@ -287,7 +287,7 @@ class LivepatchCharm(CharmBase):
         for db_name, conn_str in targets.items():
             upgrade_required = False
             try:
-                upgrade_required = self.migration_is_required(schema_container, conn_str)
+                upgrade_required = self.migration_is_required(schema_container, db_name, conn_str)
             except TransientSchemaToolError as e:
                 LOGGER.warning("transient db error while checking schema for %s, deferring: %s", db_name, e)
                 self.unit.status = WaitingStatus("Waiting for database to settle (pgbouncer)")
@@ -297,7 +297,7 @@ class LivepatchCharm(CharmBase):
 
             if upgrade_required:
                 try:
-                    self.schema_upgrade(schema_container, conn_str)
+                    self.schema_upgrade(schema_container, db_name, conn_str)
                 except TransientSchemaToolError as e:
                     LOGGER.warning("transient db error while upgrading schema for %s, deferring: %s", db_name, e)
                     self.unit.status = WaitingStatus("Waiting for database to settle (pgbouncer)")
@@ -803,7 +803,7 @@ class LivepatchCharm(CharmBase):
             return
 
         targets = self._get_schema_upgrade_targets()
-        db_uri = targets.get("primary")
+        db_uri = targets.get("livepatchdb")
         container = self.unit.get_container(SCHEMA_UPGRADE_CONTAINER)
         if not db_uri:
             LOGGER.error("DB connection string not set")
@@ -811,7 +811,7 @@ class LivepatchCharm(CharmBase):
             return
 
         if self.config.get("timescale_db.enabled"):
-            metrics_db_uri = targets.get("timescale")
+            metrics_db_uri = targets.get("timescaledb")
             if not metrics_db_uri:
                 LOGGER.error("Metrics DB connection string not set")
                 event.fail("schema migration failed: metrics database connection not set/ready")
@@ -824,7 +824,7 @@ class LivepatchCharm(CharmBase):
 
         for db_name, conn_str in targets.items():
             try:
-                self.schema_upgrade(container, conn_str)
+                self.schema_upgrade(container, db_name, conn_str)
             except Exception as e:
                 event.fail(f"schema migration failed for {db_name} database: {e}")
                 return
@@ -836,7 +836,7 @@ class LivepatchCharm(CharmBase):
             return False
         return any(marker in stderr for marker in TRANSIENT_SCHEMA_TOOL_MARKERS)
 
-    def schema_upgrade(self, container, conn_str):
+    def schema_upgrade(self, container, target, conn_str):
         """
         Perform a schema upgrade on the configurable database.
 
@@ -861,6 +861,8 @@ class LivepatchCharm(CharmBase):
                         "upgrade",
                         "--db",
                         conn_str,
+                        "--target",
+                        target,
                     ],
                 )
             except pebble.APIError as e:
@@ -900,19 +902,35 @@ class LivepatchCharm(CharmBase):
             LOGGER.warning("State is not ready")
             return
 
-        db_uri = self._state.dsn
+        targets = self._get_schema_upgrade_targets()
         container = self.unit.get_container(SCHEMA_UPGRADE_CONTAINER)
-        if not container.can_connect():
-            LOGGER.error("cannot connect to the schema update container")
+        db_uri = targets.get("livepatchdb")
+        if not db_uri:
+            LOGGER.error("DB connection string not set")
+            event.fail("schema migration failed: database connection not set/ready")
             return
 
-        try:
-            migration_required = self.migration_is_required(container, db_uri)
-            event.set_results({"migration-required": migration_required})
-        except Exception as e:
-            event.fail(f"schema version check failed: {e}")
+        if self.config.get("timescale_db.enabled"):
+            metrics_db_uri = targets.get("timescaledb")
+            if not metrics_db_uri:
+                LOGGER.error("Metrics DB connection string not set")
+                event.fail("schema migration failed: metrics database connection not set/ready")
+                return
 
-    def migration_is_required(self, container, conn_str: str) -> bool:
+        if not container.can_connect():
+            LOGGER.error("cannot connect to the schema upgrade container")
+            event.fail("schema migration failed: cannot connect to the schema upgrade container")
+            return
+
+        for db_name, conn_str in targets.items():
+            try:
+                migration_required = self.migration_is_required(container, db_name, conn_str)
+                event.set_results({f"migration-required-{db_name}": migration_required})
+            except Exception as e:
+                event.fail(f"schema version check failed for {db_name}: {e}")
+                return
+
+    def migration_is_required(self, container, target, conn_str: str) -> bool:
         """Run a schema version check against the database."""
         if not container.exists("/usr/local/bin/livepatch-schema-tool"):
             LOGGER.error("livepatch-schema-tool not found in the schema upgrade container")
@@ -930,6 +948,8 @@ class LivepatchCharm(CharmBase):
                         "check",
                         "--db",
                         conn_str,
+                        "--target",
+                        target,
                     ],
                 )
             except pebble.APIError as e:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,7 +16,14 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import ActionFailed, Harness
 
 from log_redactor import _REDACTED
-from src.charm import LIVEPATCH_SERVICE_NAME, SERVER_PORT, LivepatchCharm
+from src.charm import (
+    LIVEPATCH_SERVICE_NAME,
+    SCHEMA_TOOL_MAX_ATTEMPTS,
+    SERVER_PORT,
+    DeferError,
+    LivepatchCharm,
+    TransientSchemaToolError,
+)
 from src.state import State
 
 APP_NAME = "canonical-livepatch-server-k8s"
@@ -262,6 +269,122 @@ class TestCharm(unittest.TestCase):
             "schema migration failed for primary database: non-zero exit code 1 executing '/usr/local/bin/livepatch-schema-tool', stdout='', stderr='some error'",
         )
 
+    @staticmethod
+    def _make_schema_container(wait_output_effects: List[Any]) -> Mock:
+        """Build a mock schema-upgrade container.
+
+        `wait_output_effects` is a list of per-attempt behaviors for
+        `process.wait_output()`. Each item is either an exception instance (to
+        raise) or a (stdout, stderr) tuple (to return).
+        """
+        container = Mock()
+        container.exists = Mock(return_value=True)
+
+        effects = iter(wait_output_effects)
+
+        def exec_side_effect(command: List[str]):
+            effect = next(effects)
+
+            def wait_output():
+                if isinstance(effect, Exception):
+                    raise effect
+                return effect
+
+            process_mock = Mock()
+            process_mock.wait_output.side_effect = wait_output
+            return process_mock
+
+        container.exec = Mock(side_effect=exec_side_effect)
+        return container
+
+    @staticmethod
+    def _transient_exec_error() -> pebble.ExecError:
+        return pebble.ExecError(
+            ["/usr/local/bin/livepatch-schema-tool"],
+            1,
+            "",
+            'ERROR: prepared statement "lrupsc_1_0" already exists (SQLSTATE 42P05)',
+        )
+
+    @patch("src.charm.time.sleep", return_value=None)
+    def test_schema_upgrade__retries_then_succeeds(self, _sleep):
+        """A transient error clears on retry and the upgrade succeeds."""
+        self.start_container()
+        container = self._make_schema_container(
+            [self._transient_exec_error(), self._transient_exec_error(), (None, None)]
+        )
+
+        # Should not raise.
+        self.harness.charm.schema_upgrade(container, "postgresql://123")
+
+        self.assertEqual(container.exec.call_count, 3)
+
+    @patch("src.charm.time.sleep", return_value=None)
+    def test_schema_upgrade__transient_exhausted_raises(self, _sleep):
+        """A persistent transient error raises TransientSchemaToolError after max attempts."""
+        self.start_container()
+        container = self._make_schema_container([self._transient_exec_error() for _ in range(SCHEMA_TOOL_MAX_ATTEMPTS)])
+
+        with self.assertRaises(TransientSchemaToolError):
+            self.harness.charm.schema_upgrade(container, "postgresql://123")
+
+        self.assertEqual(container.exec.call_count, SCHEMA_TOOL_MAX_ATTEMPTS)
+
+    @patch("src.charm.time.sleep", return_value=None)
+    def test_schema_upgrade__non_transient_raises_immediately(self, _sleep):
+        """A non-transient error is raised on the first attempt without retrying."""
+        self.start_container()
+        non_transient = pebble.ExecError(["/usr/local/bin/livepatch-schema-tool"], 1, "", "some error")
+        container = self._make_schema_container([non_transient])
+
+        with self.assertRaises(pebble.ExecError):
+            self.harness.charm.schema_upgrade(container, "postgresql://123")
+
+        self.assertEqual(container.exec.call_count, 1)
+
+    @patch("src.charm.time.sleep", return_value=None)
+    def test_migration_is_required__retries_then_returns(self, _sleep):
+        """The schema check retries transient errors then returns the result."""
+        self.start_container()
+        container = self._make_schema_container([self._transient_exec_error(), (None, None)])
+
+        self.assertFalse(self.harness.charm.migration_is_required(container, "postgresql://123"))
+        self.assertEqual(container.exec.call_count, 2)
+
+    @patch("src.charm.time.sleep", return_value=None)
+    def test_migration_is_required__exit_code_2_is_pending(self, _sleep):
+        """Exit code 2 means migrations are pending and is not retried."""
+        self.start_container()
+        pending = pebble.ExecError(["/usr/local/bin/livepatch-schema-tool"], 2, "", "pending")
+        container = self._make_schema_container([pending])
+
+        self.assertTrue(self.harness.charm.migration_is_required(container, "postgresql://123"))
+        self.assertEqual(container.exec.call_count, 1)
+
+    @patch("src.charm.time.sleep", return_value=None)
+    def test_migration_is_required__transient_exhausted_raises(self, _sleep):
+        """A persistent transient error during check raises TransientSchemaToolError."""
+        self.start_container()
+        container = self._make_schema_container([self._transient_exec_error() for _ in range(SCHEMA_TOOL_MAX_ATTEMPTS)])
+
+        with self.assertRaises(TransientSchemaToolError):
+            self.harness.charm.migration_is_required(container, "postgresql://123")
+        self.assertEqual(container.exec.call_count, SCHEMA_TOOL_MAX_ATTEMPTS)
+
+    def test_handle_schema_upgrade__transient_defers(self):
+        """handle_schema_upgrade converts a transient schema-tool error into a defer."""
+        self.start_container()
+        self.harness.charm._state.dsn = "postgresql://123"
+
+        with patch.object(
+            self.harness.charm,
+            "migration_is_required",
+            side_effect=TransientSchemaToolError("42P05"),
+        ):
+            with self.assertRaises(DeferError):
+                self.harness.charm.handle_schema_upgrade()
+
+        self.assertEqual(self.harness.charm.unit.status.name, WaitingStatus.name)
 
     def test_on_config_changed__failure__cannot_connect_to_schema_upgrade_container(self):
         """

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -212,6 +212,8 @@ class TestCharm(unittest.TestCase):
                     "upgrade",
                     "--db",
                     "postgresql://123",
+                    "--target",
+                    "livepatchdb",
                 ],
             )
             process_mock = Mock()
@@ -249,6 +251,8 @@ class TestCharm(unittest.TestCase):
                     "upgrade",
                     "--db",
                     "postgresql://123",
+                    "--target",
+                    "livepatchdb",
                 ],
             )
 
@@ -266,7 +270,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             ex.exception.message,
-            "schema migration failed for primary database: non-zero exit code 1 executing '/usr/local/bin/livepatch-schema-tool', stdout='', stderr='some error'",
+            "schema migration failed for livepatchdb database: non-zero exit code 1 executing '/usr/local/bin/livepatch-schema-tool', stdout='', stderr='some error'",
         )
 
     @staticmethod
@@ -315,7 +319,7 @@ class TestCharm(unittest.TestCase):
         )
 
         # Should not raise.
-        self.harness.charm.schema_upgrade(container, "postgresql://123")
+        self.harness.charm.schema_upgrade(container, "livepatchdb", "postgresql://123")
 
         self.assertEqual(container.exec.call_count, 3)
 
@@ -326,7 +330,7 @@ class TestCharm(unittest.TestCase):
         container = self._make_schema_container([self._transient_exec_error() for _ in range(SCHEMA_TOOL_MAX_ATTEMPTS)])
 
         with self.assertRaises(TransientSchemaToolError):
-            self.harness.charm.schema_upgrade(container, "postgresql://123")
+            self.harness.charm.schema_upgrade(container, "livepatchdb", "postgresql://123")
 
         self.assertEqual(container.exec.call_count, SCHEMA_TOOL_MAX_ATTEMPTS)
 
@@ -338,7 +342,7 @@ class TestCharm(unittest.TestCase):
         container = self._make_schema_container([non_transient])
 
         with self.assertRaises(pebble.ExecError):
-            self.harness.charm.schema_upgrade(container, "postgresql://123")
+            self.harness.charm.schema_upgrade(container, "livepatchdb", "postgresql://123")
 
         self.assertEqual(container.exec.call_count, 1)
 
@@ -348,7 +352,7 @@ class TestCharm(unittest.TestCase):
         self.start_container()
         container = self._make_schema_container([self._transient_exec_error(), (None, None)])
 
-        self.assertFalse(self.harness.charm.migration_is_required(container, "postgresql://123"))
+        self.assertFalse(self.harness.charm.migration_is_required(container, "livepatchdb", "postgresql://123"))
         self.assertEqual(container.exec.call_count, 2)
 
     @patch("src.charm.time.sleep", return_value=None)
@@ -358,7 +362,7 @@ class TestCharm(unittest.TestCase):
         pending = pebble.ExecError(["/usr/local/bin/livepatch-schema-tool"], 2, "", "pending")
         container = self._make_schema_container([pending])
 
-        self.assertTrue(self.harness.charm.migration_is_required(container, "postgresql://123"))
+        self.assertTrue(self.harness.charm.migration_is_required(container, "livepatchdb", "postgresql://123"))
         self.assertEqual(container.exec.call_count, 1)
 
     @patch("src.charm.time.sleep", return_value=None)
@@ -368,7 +372,7 @@ class TestCharm(unittest.TestCase):
         container = self._make_schema_container([self._transient_exec_error() for _ in range(SCHEMA_TOOL_MAX_ATTEMPTS)])
 
         with self.assertRaises(TransientSchemaToolError):
-            self.harness.charm.migration_is_required(container, "postgresql://123")
+            self.harness.charm.migration_is_required(container, "livepatchdb", "postgresql://123")
         self.assertEqual(container.exec.call_count, SCHEMA_TOOL_MAX_ATTEMPTS)
 
     def test_handle_schema_upgrade__transient_defers(self):
@@ -463,6 +467,8 @@ class TestCharm(unittest.TestCase):
                     "check",
                     "--db",
                     "postgresql://123",
+                    "--target",
+                    "livepatchdb",
                 ],
             )
             process_mock = Mock()
@@ -473,7 +479,7 @@ class TestCharm(unittest.TestCase):
 
         output = self.harness.run_action("schema-version")
 
-        self.assertEqual(output.results, {"migration-required": False})
+        self.assertEqual(output.results, {"migration-required-livepatchdb": False})
 
     def test_schema_version_action__success__migration_required(self):
         """
@@ -502,6 +508,8 @@ class TestCharm(unittest.TestCase):
                     "check",
                     "--db",
                     "postgresql://123",
+                    "--target",
+                    "livepatchdb",
                 ],
             )
 
@@ -516,7 +524,7 @@ class TestCharm(unittest.TestCase):
 
         output = self.harness.run_action("schema-version")
 
-        self.assertEqual(output.results, {"migration-required": True})
+        self.assertEqual(output.results, {"migration-required-livepatchdb": True})
 
     def test_schema_version_action__failure(self):
         """Test the scenario where `schema-version` action fails."""
@@ -542,6 +550,8 @@ class TestCharm(unittest.TestCase):
                     "check",
                     "--db",
                     "postgresql://123",
+                    "--target",
+                    "livepatchdb",
                 ],
             )
 
@@ -559,7 +569,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             ex.exception.message,
-            "schema version check failed: non-zero exit code 1 executing '/usr/local/bin/livepatch-schema-tool', stdout='', stderr='some error'",
+            "schema version check failed for livepatchdb: non-zero exit code 1 executing '/usr/local/bin/livepatch-schema-tool', stdout='', stderr='some error'",
         )
 
     def test_get_resource_token_action__success(self):

--- a/tests/unit/test_timescale_db.py
+++ b/tests/unit/test_timescale_db.py
@@ -3,11 +3,11 @@
 
 """Additional unit tests specifically for MetricsDB functionality."""
 
-from typing import Any, Dict
-import unittest
-from unittest.mock import Mock, patch
-import pathlib
 import os
+import pathlib
+import unittest
+from typing import Any, Dict
+from unittest.mock import Mock, patch
 
 from ops.testing import Harness
 
@@ -101,7 +101,6 @@ class TestMetricsDBFunctionality(unittest.TestCase):
         with patch.object(self.harness.charm.metrics_db, "is_resource_created", return_value=True), patch.object(
             self.harness.charm.metrics_db, "fetch_relation_data", return_value=mock_relation_data
         ):
-
             db_info = self.harness.charm._get_db_info(self.harness.charm.metrics_db)
 
             self.assertIsNotNone(db_info)
@@ -125,7 +124,6 @@ class TestMetricsDBFunctionality(unittest.TestCase):
         with patch.object(self.harness.charm.metrics_db, "is_resource_created", return_value=True), patch.object(
             self.harness.charm.metrics_db, "fetch_relation_data", return_value={}
         ):
-
             db_info = self.harness.charm._get_db_info(self.harness.charm.metrics_db)
             self.assertIsNone(db_info)
 
@@ -143,12 +141,16 @@ class TestMetricsDBFunctionality(unittest.TestCase):
                 self.harness.charm.handle_schema_upgrade()
 
         self.assertEqual(migration.call_count, 2)
-        self.assertEqual(migration.call_args_list[0].args[1], "postgresql://primary")
-        self.assertEqual(migration.call_args_list[1].args[1], "postgresql://timescale")
+        self.assertEqual(migration.call_args_list[0].args[1], "livepatchdb")
+        self.assertEqual(migration.call_args_list[0].args[2], "postgresql://primary")
+        self.assertEqual(migration.call_args_list[1].args[1], "timescaledb")
+        self.assertEqual(migration.call_args_list[1].args[2], "postgresql://timescale")
 
         self.assertEqual(schema_upgrade.call_count, 2)
-        self.assertEqual(schema_upgrade.call_args_list[0].args[1], "postgresql://primary")
-        self.assertEqual(schema_upgrade.call_args_list[1].args[1], "postgresql://timescale")
+        self.assertEqual(schema_upgrade.call_args_list[0].args[1], "livepatchdb")
+        self.assertEqual(schema_upgrade.call_args_list[0].args[2], "postgresql://primary")
+        self.assertEqual(schema_upgrade.call_args_list[1].args[1], "timescaledb")
+        self.assertEqual(schema_upgrade.call_args_list[1].args[2], "postgresql://timescale")
 
     def test_schema_upgrade_action_runs_for_timescale_when_enabled(self):
         """Test schema-upgrade action upgrades both primary and Timescale databases."""
@@ -164,8 +166,10 @@ class TestMetricsDBFunctionality(unittest.TestCase):
             self.harness.run_action("schema-upgrade")
 
         self.assertEqual(schema_upgrade.call_count, 2)
-        self.assertEqual(schema_upgrade.call_args_list[0].args[1], "postgresql://primary")
-        self.assertEqual(schema_upgrade.call_args_list[1].args[1], "postgresql://timescale")
+        self.assertEqual(schema_upgrade.call_args_list[0].args[1], "livepatchdb")
+        self.assertEqual(schema_upgrade.call_args_list[0].args[2], "postgresql://primary")
+        self.assertEqual(schema_upgrade.call_args_list[1].args[1], "timescaledb")
+        self.assertEqual(schema_upgrade.call_args_list[1].args[2], "postgresql://timescale")
 
     def test_metrics_db_event_handles_relation_created(self):
         """Test MetricsDB relation created event is handled properly."""
@@ -185,7 +189,7 @@ class TestMetricsDBFunctionality(unittest.TestCase):
         )
 
         self.harness.charm._on_metrics_db_event(Mock(relation=Mock(name="metrics-db")))
-    
+
         expected_dsn = "postgresql://tsuser:tspass@postgres.local:5432/livepatch-metrics-db"
         self.assertEqual(self.harness.charm._state.dsn_metrics, expected_dsn)
 

--- a/tests/unit/test_timescale_db.py
+++ b/tests/unit/test_timescale_db.py
@@ -9,7 +9,7 @@ import unittest
 from typing import Any, Dict
 from unittest.mock import Mock, patch
 
-from ops.testing import ActionFailed, Harness
+from ops.testing import Harness
 
 from src.charm import LivepatchCharm
 

--- a/tox.ini
+++ b/tox.ini
@@ -100,6 +100,9 @@ description = Run integration tests
 deps =
     pytest
     juju~=2.9
+    # pylibjuju 2.9 declares an unbounded `kubernetes>=12.0.1`; kubernetes 36.0.0
+    # breaks its k8s cloud handling and surfaces as Calico pod-sandbox failures.
+    kubernetes<36.0.0
     pytest-operator~=0.37.0
     pytest-asyncio
     requests
@@ -143,6 +146,9 @@ description = Run airgapped integration tests
 deps =
     pytest
     juju~=2.9
+    # pylibjuju 2.9 declares an unbounded `kubernetes>=12.0.1`; kubernetes 36.0.0
+    # breaks its k8s cloud handling and surfaces as Calico pod-sandbox failures.
+    kubernetes<36.0.0
     pytest-operator~=0.37.0
     pytest-asyncio
     requests


### PR DESCRIPTION
## Description

Defensive handling of possible errors when using pgbouncer, when the migrations fail due to problems from the connection persisting (see https://github.com/canonical/pgbouncer-k8s-operator/issues/740), the charm waits and retries up to a limit. This retry logic stabilizes the charm and allows the migrations to go through and keeps the charm out of a blocked state. 

Fixes #96

## Engineering checklist
*Check only items that apply*

- [ ] I have checked and added or updated relevant documentation.
- [ ] I have checked and added or updated relevant release notes.
- [ ] Covered by unit tests
- [ ] Covered by integration tests


## Notes for code reviewers

<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->
