### PR TITLE
Publish alerts on the OTLP relation on a charm refresh

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -89,6 +89,7 @@ class LivepatchCharm(CharmBase):
         self.framework.observe(self.on.livepatch_relation_changed, self.on_peer_relation_changed)
         self.framework.observe(self.on.config_changed, self.on_config_changed)
         self.framework.observe(self.on.update_status, self.on_update_status)
+        self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(self.on.leader_elected, self.on_leader_elected)
         self.framework.observe(self.on.livepatch_pebble_ready, self.on_pebble_ready)
         self.framework.observe(self.on.start, self.on_start)
@@ -216,6 +217,10 @@ class LivepatchCharm(CharmBase):
             jobs=[{"static_configs": [{"targets": [f"*:{SERVER_PORT}"]}]}],
             refresh_event=self.on.config_changed,
             relation_name="metrics-endpoint",
+            # Empty path disables alert rule publishing on this relation (default would load from
+            # src/prometheus_alert_rules/). Rules are sent exclusively via send-otlp to avoid
+            # duplicate rule evaluation when both relations point to the same otelcol.
+            alert_rules_path="",
         )
 
         # Grafana dashboard relation
@@ -237,6 +242,16 @@ class LivepatchCharm(CharmBase):
             LOGGER.warning("State is not ready")
             return
         self._update_workload_container_config(event)
+
+    def _on_upgrade_charm(self, event):
+        """Handle upgrade-charm hook: runs on each unit when a new charm revision is deployed.
+
+        Alert rules are re-published here because juju refresh does not trigger any relation
+        events on existing relations. Without this, updated alert rules in a new charm revision
+        would never be pushed to the OTLP provider's databag until the relation is removed and
+        re-added.
+        """
+        self.otel_metrics.publish()
 
     def on_config_changed(self, event):
         """Handle config-changed hook: refresh ingress method and reconfigure the workload."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -217,10 +217,11 @@ class LivepatchCharm(CharmBase):
             jobs=[{"static_configs": [{"targets": [f"*:{SERVER_PORT}"]}]}],
             refresh_event=self.on.config_changed,
             relation_name="metrics-endpoint",
-            # Empty path disables alert rule publishing on this relation (default would load from
-            # src/prometheus_alert_rules/). Rules are sent exclusively via send-otlp to avoid
+            # Non-existent path disables alert rule publishing on this relation (default would load
+            # from src/prometheus_alert_rules/). The library raises InvalidAlertRulePathError which
+            # it catches internally and no-ops. Rules are sent exclusively via send-otlp to avoid
             # duplicate rule evaluation when both relations point to the same otelcol.
-            alert_rules_path="",
+            alert_rules_path="./no_prometheus_alert_rules",
         )
 
         # Grafana dashboard relation

--- a/src/charm.py
+++ b/src/charm.py
@@ -76,7 +76,7 @@ class LivepatchCharm(CharmBase):
     traefik-k8s).
     """
 
-    def __init__(self, *args):
+    def __init__(self, *args):  # pylint: disable=too-many-statements
         """Initialise the charm, register event observers, and set up integrations."""
         super().__init__(*args)
         setup_log_redaction()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -203,7 +203,8 @@ class TestCharm(unittest.TestCase):
         databag_before = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
         self.assertNotIn("rules", databag_before)
 
-        self.harness.charm._on_upgrade_charm(None)
+        with patch("subprocess.check_call", return_value=None):  # suppress pgsql's leader-set call
+            self.harness.charm.on.upgrade_charm.emit()
 
         # After upgrade: rules are present in the databag.
         databag_after = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
@@ -218,7 +219,8 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
 
         # Should not raise
-        self.harness.charm._on_upgrade_charm(None)
+        with patch("subprocess.check_call", return_value=None):  # suppress pgsql's leader-set call
+            self.harness.charm.on.upgrade_charm.emit()
 
     def test_on_stop(self):
         """Test on-stop event handler."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -172,6 +172,24 @@ class TestCharm(unittest.TestCase):
         alert_names = {rule["alert"] for group in groups for rule in group.get("rules", []) if "alert" in rule}
         self.assertTrue(EXPECTED_PROMETHEUS_ALERTS.issubset(alert_names))
 
+    def test_alert_rules_not_published_on_metrics_endpoint(self):
+        """Alert rules are not published on the metrics-endpoint relation.
+
+        Rules are sent exclusively via send-otlp; the metrics-endpoint relation is used
+        only for scrape job configuration to avoid duplicate rule evaluation in the backend.
+        """
+        self.harness.set_leader(True)
+        rel_id = self.harness.add_relation("metrics-endpoint", "prometheus-k8s")
+        self.harness.add_relation_unit(rel_id, "prometheus-k8s/0")
+
+        self.harness.charm.metrics_endpoint.set_scrape_job_spec()
+
+        databag = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        # Verify the provider actually ran and wrote scrape data.
+        self.assertIn("scrape_jobs", databag)
+        # Verify alert rules were not included.
+        self.assertNotIn("alert_rules", databag)
+
     def test_upgrade_charm_republishes_alert_rules(self):
         """Alert rules are re-published to the send-otlp databag on upgrade-charm.
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -172,6 +172,36 @@ class TestCharm(unittest.TestCase):
         alert_names = {rule["alert"] for group in groups for rule in group.get("rules", []) if "alert" in rule}
         self.assertTrue(EXPECTED_PROMETHEUS_ALERTS.issubset(alert_names))
 
+    def test_upgrade_charm_republishes_alert_rules(self):
+        """Alert rules are re-published to the send-otlp databag on upgrade-charm.
+
+        Simulates the case where a charm was deployed without alert rules (empty databag)
+        and is then upgraded to a revision that includes them.
+        """
+        self.harness.set_leader(True)
+        rel_id = self.harness.add_relation("send-otlp", "opentelemetry-collector-k8s")
+
+        # Before upgrade: relation exists but databag is empty (no rules published yet).
+        databag_before = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertNotIn("rules", databag_before)
+
+        self.harness.charm._on_upgrade_charm(None)
+
+        # After upgrade: rules are present in the databag.
+        databag_after = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
+        self.assertIn("rules", databag_after)
+        decoded = json.loads(LZMABase64.decompress(json.loads(databag_after["rules"])))
+        groups = decoded["promql"].get("groups", [])
+        alert_names = {rule["alert"] for group in groups for rule in group.get("rules", []) if "alert" in rule}
+        self.assertTrue(EXPECTED_PROMETHEUS_ALERTS.issubset(alert_names))
+
+    def test_upgrade_charm_no_otlp_relation_does_not_error(self):
+        """upgrade-charm completes without error when no send-otlp relation exists."""
+        self.harness.set_leader(True)
+
+        # Should not raise
+        self.harness.charm._on_upgrade_charm(None)
+
     def test_on_stop(self):
         """Test on-stop event handler."""
         self.start_container()


### PR DESCRIPTION
## Description

Currently, the publish() method of the OTLPRequirer object, only gets called on relation creation and change. However, if a charm that already has the `otlp` interface relation is upgraded to a new revision with updated alert rules, the new alert rules will not be published over the relation. This PR aims to publish the otlp relation on every charm upgrade so that updated alert rules are always sent over the `otlp` interface relation.

This PR also adds a non-existent alert rule path for the metrics-endpoint relation, to ensure that alerts are only forwarded in one relation and no duplicate alert rules are created in COS. By default, the metrics-endpoint relation will pick up the alert rules from the prometheus-alert-rules directory and send it forward. We are avoiding this as we only want to send it over the `otlp` relation

Fixes *CSS-23406*

## Engineering checklist
*Check only items that apply*

- [ ] I have checked and added or updated relevant documentation.
- [ ] I have checked and added or updated relevant release notes.
- [ ] Covered by unit tests
- [ ] Covered by integration tests


## Notes for code reviewers

<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->
